### PR TITLE
Remove .env from repo and document local file

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,0 @@
-SECRET_KEY=parana-clube-1989
-MAX_CONTENT_LENGTH=16777216   # 16 MB, ajuste se precisar

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Exemplo de variáveis de ambiente
+SECRET_KEY=sua-chave-secreta
+MAX_CONTENT_LENGTH=16777216  # 16 MB, ajuste se precisar

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ venv\Scripts\activate
 ```bash
 pip install -r requirements.txt
 ```
+4. Crie um arquivo `.env` na raiz do projeto (opcionalmente copie `.env.example`):
+```bash
+cp .env.example .env
+```
 
 ---
 


### PR DESCRIPTION
## Summary
- remove `.env` from version control
- add `.env.example` with default vars
- instruct developers how to create a local `.env`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6846eee18a6483218bfbc825ab6c47fa