### PR TITLE
Remove unused imports in converter route

### DIFF
--- a/app/routes/converter.py
+++ b/app/routes/converter.py
@@ -1,7 +1,5 @@
 from flask import Blueprint, request, jsonify, send_file, render_template, after_this_request
 import os
-from flask_limiter import Limiter
-from flask_limiter.util import get_remote_address
 from ..services.converter_service import (
     converter_doc_para_pdf,
     converter_planilha_para_pdf


### PR DESCRIPTION
## Summary
- clean up unused Limiter imports in converter route module

## Testing
- `python -m py_compile app/routes/converter.py`
- `python -m compileall app`

------
https://chatgpt.com/codex/tasks/task_e_6847123a50d88321a80f0c97b434fdf8