### PR TITLE
Clarify SECRET_KEY requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ pip install -r requirements.txt
 ```bash
 cp .env.example .env
 ```
+5. No arquivo `.env`, defina a variável `SECRET_KEY` com um valor aleatório.
+   Sem essa chave o app exibirá erros de CSRF e não funcionará.
 
 ---
 


### PR DESCRIPTION
## Summary
- mention that `SECRET_KEY` must be set in `.env`
- warn about CSRF errors if omitted

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847123f55dc8321b34935271edc7768