### PR TITLE
Add environment variable overrides for binaries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,9 @@
 # Exemplo de variáveis de ambiente
 SECRET_KEY=sua-chave-secreta
 MAX_CONTENT_LENGTH=16777216  # 16 MB, ajuste se precisar
+
+# Caminho opcional para o executável do LibreOffice (soffice)
+#LIBREOFFICE_BIN=/usr/bin/libreoffice
+
+# Caminho opcional para o executável do Ghostscript
+#GHOSTSCRIPT_BIN=/usr/bin/gs

--- a/README.md
+++ b/README.md
@@ -61,6 +61,16 @@ cp .env.example .env
 ```
 5. No arquivo `.env`, defina a variável `SECRET_KEY` com um valor aleatório.
    Sem essa chave o app exibirá erros de CSRF e não funcionará.
+6. (Opcional) Defina `LIBREOFFICE_BIN` ou `GHOSTSCRIPT_BIN` caso os executáveis
+   não estejam no seu `PATH`.
+
+### Variáveis de ambiente
+
+- **`LIBREOFFICE_BIN`**: caminho para o executável do LibreOffice (`soffice`).
+- **`GHOSTSCRIPT_BIN`**: caminho para o executável do Ghostscript.
+
+Se não definidas, o aplicativo utiliza `libreoffice` e `gs` (Linux) ou os
+caminhos padrão do Windows.
 
 ---
 

--- a/app/services/compress_service.py
+++ b/app/services/compress_service.py
@@ -4,6 +4,9 @@ import platform
 from werkzeug.utils import secure_filename
 from ..utils.config_utils import ensure_upload_folder_exists
 
+# Caminho opcional para o binário do Ghostscript.
+GHOSTSCRIPT_BIN = os.environ.get("GHOSTSCRIPT_BIN")
+
 def comprimir_pdf(file):
     upload_folder = os.path.join(os.getcwd(), 'uploads')
     ensure_upload_folder_exists(upload_folder)
@@ -19,10 +22,12 @@ def comprimir_pdf(file):
     output_path = os.path.join(upload_folder, f"comprimido_{base}.pdf")
 
     # Escolhe o binário do Ghostscript de acordo com o sistema
-    if platform.system() == 'Windows':
-        ghostscript_cmd = r"C:\Program Files\gs\gs10.05.0\bin\gswin64c.exe"
-    else:
-        ghostscript_cmd = "gs"
+    ghostscript_cmd = GHOSTSCRIPT_BIN
+    if not ghostscript_cmd:
+        if platform.system() == 'Windows':
+            ghostscript_cmd = r"C:\Program Files\gs\gs10.05.0\bin\gswin64c.exe"
+        else:
+            ghostscript_cmd = "gs"
 
     gs_cmd = [
         ghostscript_cmd,

--- a/app/services/converter_service.py
+++ b/app/services/converter_service.py
@@ -5,6 +5,9 @@ from werkzeug.utils import secure_filename
 from PIL import Image
 from ..utils.config_utils import allowed_file, ensure_upload_folder_exists
 
+# Caminho opcional para o binário do LibreOffice.
+LIBREOFFICE_BIN = os.environ.get("LIBREOFFICE_BIN")
+
 
 def converter_doc_para_pdf(file):
     """Converte documentos suportados (DOC/DOCX/ODT) e imagens (JPG/PNG) para PDF."""
@@ -28,10 +31,12 @@ def converter_doc_para_pdf(file):
         rgb_image.save(output_path, 'PDF')
     else:
         # Para documentos, utiliza LibreOffice headless
-        if platform.system() == 'Windows':
-            libreoffice_cmd = r"C:\Program Files\LibreOffice\program\soffice.exe"
-        else:
-            libreoffice_cmd = 'libreoffice'
+        libreoffice_cmd = LIBREOFFICE_BIN
+        if not libreoffice_cmd:
+            if platform.system() == 'Windows':
+                libreoffice_cmd = r"C:\Program Files\LibreOffice\program\soffice.exe"
+            else:
+                libreoffice_cmd = 'libreoffice'
 
         subprocess.run([
             libreoffice_cmd,
@@ -59,10 +64,12 @@ def converter_planilha_para_pdf(file):
     file.save(input_path)
 
     # Define comando do LibreOffice conforme sistema operacional
-    if platform.system() == 'Windows':
-        libreoffice_cmd = r"C:\Program Files\LibreOffice\program\soffice.exe"
-    else:
-        libreoffice_cmd = 'libreoffice'
+    libreoffice_cmd = LIBREOFFICE_BIN
+    if not libreoffice_cmd:
+        if platform.system() == 'Windows':
+            libreoffice_cmd = r"C:\Program Files\LibreOffice\program\soffice.exe"
+        else:
+            libreoffice_cmd = 'libreoffice'
 
     # Executa conversão para PDF
     subprocess.run([


### PR DESCRIPTION
## Summary
- allow custom libreoffice and ghostscript paths via optional env vars
- document `LIBREOFFICE_BIN` and `GHOSTSCRIPT_BIN`

## Testing
- `python -m py_compile app/services/converter_service.py app/services/compress_service.py`

------
https://chatgpt.com/codex/tasks/task_e_6847252213ec832198d7368325ebba09