### PR TITLE
Use unique filenames for generated PDFs

### DIFF
--- a/app/routes/split.py
+++ b/app/routes/split.py
@@ -2,6 +2,7 @@ from flask import Blueprint, request, jsonify, send_file, render_template, curre
 from ..services.split_service import dividir_pdf
 import os
 import zipfile
+import uuid
 from .. import limiter
 
 split_bp = Blueprint('split', __name__)
@@ -22,7 +23,8 @@ def split():
         pdf_paths = dividir_pdf(file)
 
         # Compacta as páginas em um .zip para facilitar o download
-        zip_path = os.path.join(current_app.config['UPLOAD_FOLDER'], 'pdf_dividido.zip')
+        zip_filename = f"{uuid.uuid4().hex}.zip"
+        zip_path = os.path.join(current_app.config['UPLOAD_FOLDER'], zip_filename)
         with zipfile.ZipFile(zip_path, 'w') as zipf:
             for pdf in pdf_paths:
                 zipf.write(pdf, os.path.basename(pdf))

--- a/app/services/compress_service.py
+++ b/app/services/compress_service.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import platform
+import uuid
 from flask import current_app
 from werkzeug.utils import secure_filename
 from ..utils.config_utils import ensure_upload_folder_exists
@@ -20,7 +21,8 @@ def comprimir_pdf(file):
 
     # Garante que o arquivo de saída tenha extensão .pdf
     base, _ = os.path.splitext(filename)
-    output_path = os.path.join(upload_folder, f"comprimido_{base}.pdf")
+    output_filename = f"comprimido_{base}_{uuid.uuid4().hex}.pdf"
+    output_path = os.path.join(upload_folder, output_filename)
 
     # Escolhe o binário do Ghostscript de acordo com o sistema
     ghostscript_cmd = GHOSTSCRIPT_BIN

--- a/app/services/merge_service.py
+++ b/app/services/merge_service.py
@@ -1,4 +1,5 @@
 import os
+import uuid
 from flask import current_app
 from PyPDF2 import PdfMerger
 from werkzeug.utils import secure_filename
@@ -20,7 +21,8 @@ def juntar_pdfs(files):
         filenames.append(path)
         merger.append(path)
 
-    output_path = os.path.join(upload_folder, 'merged_output.pdf')
+    output_filename = f"merged_{uuid.uuid4().hex}.pdf"
+    output_path = os.path.join(upload_folder, output_filename)
     merger.write(output_path)
     merger.close()
 

--- a/app/services/split_service.py
+++ b/app/services/split_service.py
@@ -1,4 +1,5 @@
 import os
+import uuid
 from flask import current_app
 from PyPDF2 import PdfReader, PdfWriter
 from werkzeug.utils import secure_filename
@@ -21,7 +22,8 @@ def dividir_pdf(file):
         writer = PdfWriter()
         writer.add_page(page)
 
-        output_path = os.path.join(upload_folder, f"pagina_{i + 1}.pdf")
+        output_filename = f"pagina_{i + 1}_{uuid.uuid4().hex}.pdf"
+        output_path = os.path.join(upload_folder, output_filename)
         with open(output_path, 'wb') as f_out:
             writer.write(f_out)
 


### PR DESCRIPTION
## Summary
- generate unique output filenames in service modules
- handle dynamic zip filename in split route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68472b42495c832193427fe2be05e761