### PR TITLE
Fix CSP to allow Google Fonts

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -51,9 +51,9 @@ def create_app():
     csp = {
         'default-src': ["'self'"],
         'script-src': ["'self'"],
-        'style-src': ["'self'"],
+        'style-src': ["'self'", 'https://fonts.googleapis.com'],
         'img-src': ["'self'", 'data:'],
-        'font-src': ["'self'"],
+        'font-src': ["'self'", 'https://fonts.gstatic.com'],
     }
     Talisman(
         app,


### PR DESCRIPTION
## Summary
- allow Google Fonts in the Flask CSP

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848385f06e8832191b5743ad6c9b2fc