### PR TITLE
Add CSRF error handler

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,8 +1,9 @@
 import os
 from dotenv import load_dotenv
-from flask import Flask, render_template
+from flask import Flask, render_template, request, jsonify
 from flask_talisman import Talisman
 from flask_wtf import CSRFProtect
+from flask_wtf.csrf import CSRFError
 from werkzeug.middleware.proxy_fix import ProxyFix
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
@@ -100,5 +101,12 @@ def create_app():
     @app.route('/compress')
     def compress_page():
         return render_template('compress.html')
+
+    @app.errorhandler(CSRFError)
+    def handle_csrf_error(e):
+        """Return JSON or HTML when CSRF validation fails."""
+        if request.accept_mimetypes.accept_json and not request.accept_mimetypes.accept_html:
+            return jsonify({'error': 'CSRF token missing or invalid.'}), 400
+        return render_template('csrf_error.html', reason=e.description), 400
 
     return app

--- a/app/templates/csrf_error.html
+++ b/app/templates/csrf_error.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+    <meta charset="UTF-8">
+    <title>Erro de Segurança</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+    <header class="header-flex">
+        <img src="/static/GrupoVital_branca_horizontal.png" alt="Logo Grupo Vital" class="logo-flex">
+        <div class="texto-header">
+            <h2>Falha de Verificação CSRF</h2>
+        </div>
+    </header>
+
+    <main>
+        <section class="card">
+            <p>{{ reason }}</p>
+            <p>Tente recarregar a página e enviar o formulário novamente.</p>
+            <div class="nav-buttons">
+                <a href="/"><button>Voltar à Página Inicial</button></a>
+            </div>
+        </section>
+    </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- show a friendly page when CSRF check fails
- add CSRF error HTML template

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68483ca064988321b4cc6ff001ebf15a