### PR TITLE
Add python-dotenv to deps and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ source venv/bin/activate
 venv\Scripts\activate
 ```
 
-3. Instale as dependências:
+3. Instale as dependências (incluindo `python-dotenv`, utilizado para ler o arquivo `.env`):
 ```bash
 pip install -r requirements.txt
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ Werkzeug==3.1.3
 Flask-WTF==1.2.1
 PyPDF2==3.0.1
 pillow==11.1.0
-python-dotenv==1.1.0
+python-dotenv>=1.1


### PR DESCRIPTION
## Summary
- depend on `python-dotenv>=1.1`
- mention python-dotenv in install instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68483c9ef55c8321ba774fb051367258