### PR TITLE
Add FORCE_HTTPS option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,6 @@ MAX_CONTENT_LENGTH=16777216  # 16 MB, ajuste se precisar
 
 # Caminho opcional para o executável do Ghostscript
 #GHOSTSCRIPT_BIN=/usr/bin/gs
+
+# Força redirecionamento para HTTPS (true ou false)
+#FORCE_HTTPS=true

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ cp .env.example .env
 
 - **`LIBREOFFICE_BIN`**: caminho para o executável do LibreOffice (`soffice`).
 - **`GHOSTSCRIPT_BIN`**: caminho para o executável do Ghostscript.
+- **`FORCE_HTTPS`**: define se o Flask-Talisman deve forçar HTTPS (`true` ou `false`).
+  Padrão `true`.
 
 Se não definidas, o aplicativo utiliza `libreoffice` e `gs` (Linux) ou os
 caminhos padrão do Windows.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -47,6 +47,10 @@ def create_app():
     if not os.path.exists(app.config['UPLOAD_FOLDER']):
         os.makedirs(app.config['UPLOAD_FOLDER'])
 
+    # Configurar se Talisman deve forçar HTTPS
+    raw_force_https = os.environ.get("FORCE_HTTPS", "true").lower()
+    force_https = raw_force_https not in ("false", "0", "no")
+
     # Configurar políticas de segurança HTTP com Flask-Talisman
     csp = {
         'default-src': ["'self'"],
@@ -58,7 +62,7 @@ def create_app():
     Talisman(
         app,
         content_security_policy=csp,
-        force_https=True,
+        force_https=force_https,
         strict_transport_security=True,
         strict_transport_security_max_age=31536000,
         frame_options='DENY',


### PR DESCRIPTION
## Summary
- make HTTPS enforcement optional via FORCE_HTTPS env var
- document FORCE_HTTPS
- show example in `.env.example`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68483c9cfb4c8321a19aa58e5f7c5044