### PR TITLE
Add env-specific configuration files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ uploads/
 __pycache__/
 venv/
 *.pyc
+envs/.env.production

--- a/README.md
+++ b/README.md
@@ -51,16 +51,17 @@ source venv/bin/activate
 venv\Scripts\activate
 ```
 
-3. Instale as dependências (incluindo `python-dotenv`, utilizado para ler o arquivo `.env`):
+3. Instale as dependências (incluindo `python-dotenv`):
 ```bash
 pip install -r requirements.txt
 ```
-4. Crie um arquivo `.env` na raiz do projeto (opcionalmente copie `.env.example`):
+4. Crie a pasta `envs/` e copie `envs/.env.development` e `envs/.env.testing` a partir do arquivo exemplo:
 ```bash
-cp .env.example .env
+mkdir envs
+cp .env.example envs/.env.development
+cp .env.example envs/.env.testing
 ```
-5. No arquivo `.env`, defina a variável `SECRET_KEY` com um valor aleatório.
-   Sem essa chave o app exibirá erros de CSRF e não funcionará.
+5. Em cada arquivo de ambiente, defina `SECRET_KEY` com um valor aleatório. Sem essa chave o app exibirá erros de CSRF.
 6. (Opcional) Defina `LIBREOFFICE_BIN` ou `GHOSTSCRIPT_BIN` caso os executáveis
    não estejam no seu `PATH`.
 
@@ -78,7 +79,12 @@ caminhos padrão do Windows.
 
 ## ▶️ Como Executar
 
+
+Defina `FLASK_ENV` para escolher qual arquivo em `envs/` deve ser carregado (por padrão `development`).
+Para rodar em modo de testes:
 ```bash
+source venv-test/bin/activate
+export FLASK_ENV=testing
 python run.py
 ```
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -9,8 +9,6 @@ from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 import secrets
 
-# Carrega variáveis de ambiente do arquivo .env
-load_dotenv()
 
 # Limiter instanciado no módulo para ser importável pelas rotas
 limiter = Limiter(
@@ -20,6 +18,11 @@ limiter = Limiter(
 csrf = CSRFProtect()
 
 def create_app():
+    # Carrega automaticamente o arquivo .env adequado em envs/
+    env = os.environ.get('FLASK_ENV', 'development')
+    dotenv_path = os.path.join(os.getcwd(), 'envs', f'.env.{env}')
+    load_dotenv(dotenv_path, override=True)
+
     app = Flask(__name__)
 
     # Ajuste para trabalhar atrás de proxy (Render, Cloudflare, etc.)

--- a/envs/.env.development
+++ b/envs/.env.development
@@ -1,0 +1,12 @@
+# Exemplo de variáveis de ambiente
+SECRET_KEY=sua-chave-secreta
+MAX_CONTENT_LENGTH=16777216  # 16 MB, ajuste se precisar
+
+# Caminho opcional para o executável do LibreOffice (soffice)
+#LIBREOFFICE_BIN=/usr/bin/libreoffice
+
+# Caminho opcional para o executável do Ghostscript
+#GHOSTSCRIPT_BIN=/usr/bin/gs
+
+# Força redirecionamento para HTTPS (true ou false)
+#FORCE_HTTPS=true

--- a/envs/.env.testing
+++ b/envs/.env.testing
@@ -1,0 +1,12 @@
+# Exemplo de variáveis de ambiente
+SECRET_KEY=sua-chave-secreta
+MAX_CONTENT_LENGTH=16777216  # 16 MB, ajuste se precisar
+
+# Caminho opcional para o executável do LibreOffice (soffice)
+#LIBREOFFICE_BIN=/usr/bin/libreoffice
+
+# Caminho opcional para o executável do Ghostscript
+#GHOSTSCRIPT_BIN=/usr/bin/gs
+
+# Força redirecionamento para HTTPS (true ou false)
+#FORCE_HTTPS=true

--- a/tests/test_env_loading.py
+++ b/tests/test_env_loading.py
@@ -1,0 +1,14 @@
+import os
+from pathlib import Path
+from app import create_app
+
+
+def test_load_env_based_on_flask_env(monkeypatch, tmp_path):
+    envdir = tmp_path / "envs"
+    envdir.mkdir()
+    env_file = envdir / ".env.custom"
+    env_file.write_text("MY_TEST_VAR=42\n")
+    monkeypatch.setenv("FLASK_ENV", "custom")
+    monkeypatch.chdir(tmp_path)
+    create_app()
+    assert os.environ.get("MY_TEST_VAR") == "42"


### PR DESCRIPTION
## Summary
- support environment-specific .env files under `envs/`
- document the new env folder usage
- ignore production secrets
- add regression test to ensure the proper env file is loaded

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684857da2b6c8321a98d9f83e6e5ab96