### PR TITLE
Update HTTPS logic and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ venv\Scripts\activate
 pip install -r requirements.txt
 ```
 4. Os arquivos `envs/.env.development` e `envs/.env.testing` já estão no repositório.
+   Esses arquivos deixam o HTTPS desabilitado por padrão (`FORCE_HTTPS=false`).
    Edite-os conforme necessário (copie `.env.example` se algum estiver faltando).
 5. Em cada arquivo de ambiente, defina `SECRET_KEY` com um valor aleatório. Sem essa chave o app exibirá erros de CSRF.
 6. (Opcional) Defina `LIBREOFFICE_BIN` ou `GHOSTSCRIPT_BIN` caso os executáveis
@@ -66,7 +67,8 @@ pip install -r requirements.txt
 - **`LIBREOFFICE_BIN`**: caminho para o executável do LibreOffice (`soffice`).
 - **`GHOSTSCRIPT_BIN`**: caminho para o executável do Ghostscript.
 - **`FORCE_HTTPS`**: define se o Flask-Talisman deve forçar HTTPS (`true` ou `false`).
-  Padrão `true`.
+  Se não definido, o HTTPS é forçado apenas em produção. Nos arquivos de desenvolvimento e testes a opção vem como `false`.
+  Para habilitar, defina `FORCE_HTTPS=true` e limpe o cache do navegador ou use uma janela anônima para testar.
 
 Se não definidas, o aplicativo utiliza `libreoffice` e `gs` (Linux) ou os
 caminhos padrão do Windows.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -52,8 +52,12 @@ def create_app():
         os.makedirs(app.config['UPLOAD_FOLDER'])
 
     # Configurar se Talisman deve forçar HTTPS
-    raw_force_https = os.environ.get("FORCE_HTTPS", "true").lower()
-    force_https = raw_force_https not in ("false", "0", "no")
+    raw_force = os.environ.get("FORCE_HTTPS")
+    force_https = (
+        raw_force.lower() not in ("false", "0", "no")
+        if raw_force is not None
+        else env == "production"
+    )
 
     # Configurar políticas de segurança HTTP com Flask-Talisman
     csp = {

--- a/envs/.env.development
+++ b/envs/.env.development
@@ -9,4 +9,4 @@ MAX_CONTENT_LENGTH=16777216  # 16 MB, ajuste se precisar
 #GHOSTSCRIPT_BIN=/usr/bin/gs
 
 # Força redirecionamento para HTTPS (true ou false)
-#FORCE_HTTPS=true
+FORCE_HTTPS=false

--- a/envs/.env.testing
+++ b/envs/.env.testing
@@ -9,4 +9,4 @@ MAX_CONTENT_LENGTH=16777216  # 16 MB, ajuste se precisar
 #GHOSTSCRIPT_BIN=/usr/bin/gs
 
 # Força redirecionamento para HTTPS (true ou false)
-#FORCE_HTTPS=true
+FORCE_HTTPS=false


### PR DESCRIPTION
## Summary
- update `create_app` to force HTTPS only in production unless `FORCE_HTTPS` is set
- disable HTTPS by default in the development and testing env files
- document HTTPS settings in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848600f87c883218e9e0e8806a478ed