### PR TITLE
Fix merge name collisions

### DIFF
--- a/app/services/merge_service.py
+++ b/app/services/merge_service.py
@@ -16,7 +16,8 @@ def juntar_pdfs(files):
         filename = secure_filename(file.filename)
         if not filename.lower().endswith('.pdf'):
             raise Exception('Apenas arquivos PDF são permitidos.')
-        path = os.path.join(upload_folder, filename)
+        unique_filename = f"{uuid.uuid4().hex}_{filename}"
+        path = os.path.join(upload_folder, unique_filename)
         file.save(path)
         filenames.append(path)
         merger.append(path)

--- a/tests/test_upload_paths.py
+++ b/tests/test_upload_paths.py
@@ -87,6 +87,18 @@ def test_juntar_pdfs_honors_config(app, tmp_path):
         assert os.path.exists(output)
 
 
+def test_juntar_pdfs_same_filenames(app, tmp_path):
+    """Merging files with identical original names should not overwrite"""
+    with app.app_context():
+        file1 = FileStorage(stream=_simple_pdf(), filename="dup.pdf")
+        file2 = FileStorage(stream=_simple_pdf(), filename="dup.pdf")
+        output = merge_service.juntar_pdfs([file1, file2])
+        assert os.path.exists(output)
+        from PyPDF2 import PdfReader
+        reader = PdfReader(output)
+        assert len(reader.pages) == 2
+
+
 def test_dividir_pdf_honors_config(app, tmp_path):
     with app.app_context():
         file = FileStorage(stream=_simple_pdf(page_count=2), filename="split.pdf")


### PR DESCRIPTION
## Summary
- ensure incoming PDFs get unique names when merging
- test merging two PDFs with the same name

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684967a7524c8321a3dc94ddb68e593c