### PR TITLE
Handle missing extension for convert

### DIFF
--- a/app/routes/converter.py
+++ b/app/routes/converter.py
@@ -23,6 +23,8 @@ def convert():
 
     # Determina a extensão para escolher o serviço correto
     filename = secure_filename(file.filename)
+    if '.' not in filename:
+        return jsonify({'error': 'Extensão de arquivo inválida.'}), 400
     ext = filename.rsplit('.', 1)[1].lower()
 
     try:

--- a/tests/test_converter_no_extension.py
+++ b/tests/test_converter_no_extension.py
@@ -1,0 +1,12 @@
+import io
+from app import create_app
+
+
+def test_convert_without_extension_returns_400():
+    app = create_app()
+    client = app.test_client()
+    data = {
+        'file': (io.BytesIO(b'test'), 'noextension')
+    }
+    resp = client.post('/api/convert', data=data, content_type='multipart/form-data')
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- guard converter endpoint against files without extensions
- ensure 400 returned if no extension is provided
- test convert route with no-extension filename

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684967a64fcc83218d2e792f97981d60