### PR TITLE
Add timeout environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,5 +8,11 @@ MAX_CONTENT_LENGTH=16777216  # 16 MB, ajuste se precisar
 # Caminho opcional para o executável do Ghostscript
 #GHOSTSCRIPT_BIN=/usr/bin/gs
 
+# Tempo limite (segundos) para o LibreOffice
+#LIBREOFFICE_TIMEOUT=60
+
+# Tempo limite (segundos) para o Ghostscript
+#GHOSTSCRIPT_TIMEOUT=60
+
 # Força redirecionamento para HTTPS (true ou false)
 #FORCE_HTTPS=true

--- a/README.md
+++ b/README.md
@@ -71,10 +71,14 @@ sudo apt install libreoffice ghostscript
 
 ### Variáveis de ambiente
 
-- **`LIBREOFFICE_BIN`**: caminho para o executável do LibreOffice (`soffice`).  
-- **`GHOSTSCRIPT_BIN`**: caminho para o executável do Ghostscript.  
-- **`FORCE_HTTPS`**: define se o Flask-Talisman deve forçar HTTPS (`true` ou `false`).  
-  Padrão `true`.  
+- **`LIBREOFFICE_BIN`**: caminho para o executável do LibreOffice (`soffice`).
+- **`GHOSTSCRIPT_BIN`**: caminho para o executável do Ghostscript.
+- **`LIBREOFFICE_TIMEOUT`**: tempo limite (segundos) da chamada ao LibreOffice.
+  Padrão `60` (ajuste para `120` se quiser alinhar ao timeout do Gunicorn).
+- **`GHOSTSCRIPT_TIMEOUT`**: tempo limite (segundos) da chamada ao Ghostscript.
+  Padrão `60`.
+- **`FORCE_HTTPS`**: define se o Flask-Talisman deve forçar HTTPS (`true` ou `false`).
+  Padrão `true`.
 
 Se não definidas, o aplicativo utiliza `libreoffice` e `gs` (Linux) ou os  
 caminhos padrão do Windows.

--- a/app/services/compress_service.py
+++ b/app/services/compress_service.py
@@ -8,6 +8,7 @@ from ..utils.config_utils import ensure_upload_folder_exists
 
 # Caminho opcional para o binário do Ghostscript.
 GHOSTSCRIPT_BIN = os.environ.get("GHOSTSCRIPT_BIN")
+GHOSTSCRIPT_TIMEOUT = int(os.environ.get("GHOSTSCRIPT_TIMEOUT", "60"))
 
 def comprimir_pdf(file):
     upload_folder = current_app.config['UPLOAD_FOLDER']
@@ -44,6 +45,6 @@ def comprimir_pdf(file):
         input_path
     ]
 
-    subprocess.run(gs_cmd, check=True, timeout=60)
+    subprocess.run(gs_cmd, check=True, timeout=GHOSTSCRIPT_TIMEOUT)
     os.remove(input_path)
     return output_path

--- a/app/services/converter_service.py
+++ b/app/services/converter_service.py
@@ -9,6 +9,7 @@ from ..utils.config_utils import allowed_file, ensure_upload_folder_exists
 
 # Caminho opcional para o binário do LibreOffice.
 LIBREOFFICE_BIN = os.environ.get("LIBREOFFICE_BIN")
+LIBREOFFICE_TIMEOUT = int(os.environ.get("LIBREOFFICE_TIMEOUT", "60"))
 
 
 def converter_doc_para_pdf(file):
@@ -47,7 +48,7 @@ def converter_doc_para_pdf(file):
             '--convert-to', 'pdf',
             input_path,
             '--outdir', upload_folder
-        ], check=True, timeout=60)
+        ], check=True, timeout=LIBREOFFICE_TIMEOUT)
         os.rename(temp_output, unique_output)
 
     os.remove(input_path)
@@ -82,7 +83,7 @@ def converter_planilha_para_pdf(file):
         '--convert-to', 'pdf',
         input_path,
         '--outdir', upload_folder
-    ], check=True, timeout=60)
+    ], check=True, timeout=LIBREOFFICE_TIMEOUT)
 
     temp_output = os.path.splitext(input_path)[0] + '.pdf'
     unique_output = os.path.join(upload_folder, f"{uuid.uuid4().hex}.pdf")

--- a/envs/.env.development
+++ b/envs/.env.development
@@ -8,5 +8,11 @@ MAX_CONTENT_LENGTH=16777216  # 16 MB, ajuste se precisar
 # Caminho opcional para o executável do Ghostscript
 #GHOSTSCRIPT_BIN=/usr/bin/gs
 
+# Tempo limite (segundos) para o LibreOffice
+#LIBREOFFICE_TIMEOUT=60
+
+# Tempo limite (segundos) para o Ghostscript
+#GHOSTSCRIPT_TIMEOUT=60
+
 # Força redirecionamento para HTTPS (true ou false)
 FORCE_HTTPS=false

--- a/envs/.env.testing
+++ b/envs/.env.testing
@@ -8,5 +8,11 @@ MAX_CONTENT_LENGTH=16777216  # 16 MB, ajuste se precisar
 # Caminho opcional para o executável do Ghostscript
 #GHOSTSCRIPT_BIN=/usr/bin/gs
 
+# Tempo limite (segundos) para o LibreOffice
+#LIBREOFFICE_TIMEOUT=60
+
+# Tempo limite (segundos) para o Ghostscript
+#GHOSTSCRIPT_TIMEOUT=60
+
 # Força redirecionamento para HTTPS (true ou false)
 FORCE_HTTPS=false


### PR DESCRIPTION
## Summary
- add `LIBREOFFICE_TIMEOUT` and `GHOSTSCRIPT_TIMEOUT` in services
- document timeout variables in README and example env files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851669e7a9c8321a91e0cddde235009