### PR TITLE
Fix Render deployment and doc cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,4 +50,4 @@ EXPOSE ${PORT}
 USER appuser
 
 # entrypoint para iniciar via gunicorn
-ENTRYPOINT ["gunicorn", "run:app", "--bind", "0.0.0.0:${PORT}", "--workers", "4", "--timeout", "120"]
+ENTRYPOINT ["sh", "-c", "gunicorn run:app --bind 0.0.0.0:${PORT} --workers 4 --timeout 120"]

--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ sudo apt install libreoffice ghostscript
 
 - **`LIBREOFFICE_BIN`**: caminho para o executável do LibreOffice (`soffice`).
 - **`GHOSTSCRIPT_BIN`**: caminho para o executável do Ghostscript.
-codex/add-readme-section-for-max_content_length
 - **`FORCE_HTTPS`**: define se o Flask-Talisman deve forçar HTTPS (`true` ou `false`).
   Padrão `true`.
 - **`MAX_CONTENT_LENGTH`**: limite máximo em bytes para uploads. Padrão `16777216` (16 MB).


### PR DESCRIPTION
## Summary
- fix gunicorn `ENTRYPOINT` to expand `$PORT`
- remove stray text from environment variable section

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68516bdc47ec8321810ef2d2f066d4a9