### PR TITLE
Simplify upload pages

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -7,6 +7,7 @@ function getCSRFToken() {
 /* Feedback Messages */
 function mostrarMensagem(mensagem, tipo = 'sucesso') {
   const msgDiv = document.getElementById('mensagem-feedback');
+  if (!msgDiv) return;
   msgDiv.textContent = mensagem;
   msgDiv.className = tipo;
   msgDiv.style.display = 'block';
@@ -274,54 +275,27 @@ function enviarArquivoCompress(event) {
 
 /* DOM Ready */
 document.addEventListener('DOMContentLoaded', () => {
-  const dropzoneElem = document.getElementById('dropzone');
   const fileInput   = document.getElementById('file-input');
-  const listElem    = document.getElementById('lista-arquivos');
-
   const converterBtn = document.getElementById('converter-btn');
   const mergeBtn     = document.getElementById('merge-btn');
   const splitBtn     = document.getElementById('split-btn');
   const compressForm = document.querySelector('form[action="/api/compress"]');
 
-  if (converterBtn && fileInput && listElem && dropzoneElem) {
-    const handler = createFileDropzone({
-      dropzone:   dropzoneElem,
-      input:      fileInput,
-      list:       listElem,
-      extensions: ['.doc','.docx','.odt','.ods','.odp','.jpg','.jpeg','.png','.csv','.xls','.xlsx'],
-      multiple:   true
-    });
+  if (converterBtn && fileInput) {
     converterBtn.addEventListener('click', () => {
-      enviarArquivosConverter(handler.getFiles());
-      handler.clear();
+      enviarArquivosConverter(Array.from(fileInput.files));
     });
   }
 
-  if (mergeBtn && fileInput && listElem && dropzoneElem) {
-    const handlerMerge = createFileDropzone({
-      dropzone:   dropzoneElem,
-      input:      fileInput,
-      list:       listElem,
-      extensions: ['.pdf'],
-      multiple:   true
-    });
+  if (mergeBtn && fileInput) {
     mergeBtn.addEventListener('click', () => {
-      enviarArquivosMerge(handlerMerge.getFiles());
-      handlerMerge.clear();
+      enviarArquivosMerge(Array.from(fileInput.files));
     });
   }
 
-  if (splitBtn && fileInput && listElem && dropzoneElem) {
-    const handlerSplit = createFileDropzone({
-      dropzone:   dropzoneElem,
-      input:      fileInput,
-      list:       listElem,
-      extensions: ['.pdf'],
-      multiple:   false
-    });
+  if (splitBtn && fileInput) {
     splitBtn.addEventListener('click', () => {
-      enviarArquivosSplit(handlerSplit.getFiles());
-      handlerSplit.clear();
+      enviarArquivosSplit(Array.from(fileInput.files));
     });
   }
 

--- a/app/templates/converter.html
+++ b/app/templates/converter.html
@@ -21,30 +21,9 @@
 
     <main>
         <section class="card">
-            <div id="dropzone" class="dropzone">
-                <input type="file" id="file-input" accept=".doc,.docx,.odt,.ods,.odp,.jpg,.jpeg,.png,.csv,.xls,.xlsx" multiple>
-                <p>Arraste e solte arquivos aqui ou clique para selecionar.</p>
-            </div>
-
-            <input type="file" id="file-input" accept=".doc,.docx,.odt,.ods,.odp,.jpg,.jpeg,.png,.csv,.xls,.xlsx">
-            <label>Ou selecione uma pasta:</label>
-            <input type="file" id="folder-input" webkitdirectory directory multiple>
-
-            <div id="dropzone" class="dropzone">Arraste os arquivos aqui</div>
-
-            <button type="button" id="add-files-btn">Adicionar arquivos</button>
-
             <input type="file" id="file-input" accept=".doc,.docx,.odt,.ods,.odp,.jpg,.jpeg,.png,.csv,.xls,.xlsx" multiple>
-
-            <ul id="lista-arquivos"></ul>
-
-            <button type="button" id="converter-btn">Converter Todos</button>
+            <button id="converter-btn">Converter Todos</button>
         </section>
-<div id="mensagem-feedback"></div>
-<div id="loading-spinner">Processando...</div>
-<div id="progress-container" class="progress-container">
-    <div id="progress-bar" class="progress-bar"></div>
-</div>
     </main>
 
     <div class="nav-buttons">
@@ -54,7 +33,6 @@
         <a href="/"><button>Voltar à Página Inicial</button></a>
     </div>
 
-    <script src="/static/fileDropzone.js" defer></script>
-<script src="/static/script.js" defer></script>
+    <script src="/static/script.js" defer></script>
 </body>
 </html>

--- a/app/templates/merge.html
+++ b/app/templates/merge.html
@@ -21,33 +21,9 @@
 
     <main>
         <section class="card">
-
-            <label>Escolha arquivos PDF:</label>
-            <div id="dropzone" class="dropzone">
-                <input type="file" id="file-input" accept=".pdf" multiple>
-                <p>Arraste e solte arquivos aqui ou clique para selecionar.</p>
-            </div>
-
-            <input type="file" id="file-input" accept=".pdf">
-            <label>Ou selecione uma pasta:</label>
-            <input type="file" id="folder-input" webkitdirectory directory multiple>
-
-            <div id="dropzone" class="dropzone">Arraste os arquivos aqui</div>
-
-            <button type="button" id="add-files-btn">Adicionar arquivos</button>
-
             <input type="file" id="file-input" accept=".pdf" multiple>
-
-
-
-            <ul id="lista-arquivos"></ul>
             <button id="merge-btn">Juntar PDFs</button>
         </section>
-<div id="mensagem-feedback"></div>
-<div id="loading-spinner">Processando...</div>
-<div id="progress-container" class="progress-container">
-    <div id="progress-bar" class="progress-bar"></div>
-</div>
     </main>
 
     <div class="nav-buttons">
@@ -57,7 +33,6 @@
         <a href="/"><button>Voltar à Página Inicial</button></a>
     </div>
 
-    <script src="/static/fileDropzone.js" defer></script>
-<script src="/static/script.js" defer></script>
+    <script src="/static/script.js" defer></script>
 </body>
 </html>

--- a/app/templates/split.html
+++ b/app/templates/split.html
@@ -21,22 +21,9 @@
 
     <main>
         <section class="card">
-            <label>Escolha um arquivo PDF:</label>
-            <div id="dropzone" class="dropzone">
-                <input type="file" id="file-input" accept=".pdf">
-                <p>Arraste e solte arquivos aqui ou clique para selecionar.</p>
-            </div>
-
-            <div id="dropzone" class="dropzone">Arraste os arquivos aqui</div>
-
-            <ul id="lista-arquivos"></ul>
+            <input type="file" id="file-input" accept=".pdf">
             <button id="split-btn">Dividir</button>
         </section>
-<div id="mensagem-feedback"></div>
-<div id="loading-spinner">Processando...</div>
-<div id="progress-container" class="progress-container">
-    <div id="progress-bar" class="progress-bar"></div>
-</div>
     </main>
 
     <div class="nav-buttons">
@@ -46,7 +33,6 @@
         <a href="/"><button>Voltar à Página Inicial</button></a>
     </div>
 
-    <script src="/static/fileDropzone.js" defer></script>
-<script src="/static/script.js" defer></script>
+    <script src="/static/script.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- streamline converter/merge/split templates with only an input and button
- drop usage of fileDropzone helper
- adjust frontend script to work without dropzone or file list

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68598976874883218c8c0397ff64db07