### PR TITLE
Remove subtle Voltar links

### DIFF
--- a/app/templates/compress.html
+++ b/app/templates/compress.html
@@ -15,7 +15,6 @@
         <img src="/static/GrupoVital_branca_horizontal.png" alt="Logo Grupo Vital" class="logo-flex">
         <div class="texto-header">
         <h2>Comprimir PDF</h2>
-        <a href="/">← Voltar</a>
         </div>
     </header>
 

--- a/app/templates/converter.html
+++ b/app/templates/converter.html
@@ -15,7 +15,6 @@
         <img src="/static/GrupoVital_branca_horizontal.png" alt="Logo Grupo Vital" class="logo-flex">
         <div class="texto-header">
         <h2>Conversão de Arquivos para PDF</h2>
-        <a href="/">← Voltar</a>
         </div>
     </header>
 

--- a/app/templates/merge.html
+++ b/app/templates/merge.html
@@ -15,7 +15,6 @@
         <img src="/static/GrupoVital_branca_horizontal.png" alt="Logo Grupo Vital" class="logo-flex">
         <div class="texto-header">
         <h2>Juntar Vários PDFs</h2>
-        <a href="/">← Voltar</a>
         </div>
     </header>
 

--- a/app/templates/split.html
+++ b/app/templates/split.html
@@ -15,7 +15,6 @@
         <img src="/static/GrupoVital_branca_horizontal.png" alt="Logo Grupo Vital" class="logo-flex">
         <div class="texto-header">
             <h2>Dividir PDF em Páginas</h2>
-            <a href="/">← Voltar</a>
         </div>
     </header>
 


### PR DESCRIPTION
## Summary
- remove the small "Voltar" links from converter, merge, split and compress pages

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68599c876a508321bfe267c448ed3fa9