### PR TITLE
Atualiza README com comando Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,11 @@ Se preferir, é possível executar o projeto usando Docker:
 docker build -t grupovital-pdfs .
 
 # executar expondo a porta desejada
-docker run -p 5000:5000 --env-file envs/.env.development grupovital-pdfs
+docker run -p 5000:5000 --env-file envs/.env.development -e FLASK_ENV=development grupovital-pdfs
 ```
+
+A opção `-e FLASK_ENV=development` garante que o Flask carregue o arquivo de
+ambiente correspondente.
 
 Depois acesse `http://localhost:5000` no navegador.
 


### PR DESCRIPTION
## Resumo
- adiciona a variável `FLASK_ENV` ao comando `docker run`
- explica a importância da flag para carregar o arquivo de ambiente correto

## Testes
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ad2aca1088321b9a97c1dd38bae35