### PR TITLE
Habilita ordenação manual de PDFs

### DIFF
--- a/app/static/fileDropzone.js
+++ b/app/static/fileDropzone.js
@@ -10,19 +10,49 @@
     } = options;
     let files = [];
 
+    function moverArquivo(index, offset){
+      const novoIndex = index + offset;
+      if(novoIndex < 0 || novoIndex >= files.length) return;
+      const [item] = files.splice(index, 1);
+      files.splice(novoIndex, 0, item);
+      updateList();
+      onChange(files);
+    }
+
     function updateList(){
       if(!list) return;
       list.innerHTML = '';
       files.forEach((f, i) => {
         const li = document.createElement('li');
-        li.textContent = f.name;
+
+        const span = document.createElement('span');
+        span.textContent = f.name;
+        li.appendChild(span);
+
+        const actions = document.createElement('div');
+        actions.style.display = 'flex';
+        actions.style.gap = '4px';
+
+        const up = document.createElement('button');
+        up.className = 'icon-btn';
+        up.textContent = '↑';
+        up.addEventListener('click', () => moverArquivo(i, -1));
+
+        const down = document.createElement('button');
+        down.className = 'icon-btn';
+        down.textContent = '↓';
+        down.addEventListener('click', () => moverArquivo(i, 1));
 
         const del = document.createElement('button');
         del.className = 'icon-btn';
         del.textContent = '🗑';
         del.addEventListener('click', () => removerArquivo(i));
 
-        li.appendChild(del);
+        actions.appendChild(up);
+        actions.appendChild(down);
+        actions.appendChild(del);
+
+        li.appendChild(actions);
         list.appendChild(li);
       });
     }

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -182,6 +182,11 @@ input[type="file"] {
     color: var(--primary-dark);
 }
 
+#lista-arquivos .actions {
+    display: flex;
+    gap: 4px;
+}
+
 .dropzone {
     border: 2px dashed #ccc;
     padding: 20px;

--- a/app/templates/merge.html
+++ b/app/templates/merge.html
@@ -24,6 +24,7 @@
                 <input type="file" id="file-input" accept=".pdf" multiple>
                 Arraste os arquivos aqui ou clique para selecionar
             </div>
+            <p>Use os botões ↑ e ↓ ao lado de cada arquivo para definir a ordem.</p>
             <ul id="lista-arquivos"></ul>
             <button id="merge-btn">Juntar PDFs</button>
         </section>

--- a/tests/test_merge_order.py
+++ b/tests/test_merge_order.py
@@ -1,0 +1,30 @@
+from io import BytesIO
+from werkzeug.datastructures import FileStorage
+from PyPDF2 import PdfWriter, PdfReader
+from app import create_app
+from app.services import merge_service
+
+
+def _pdf(w, h):
+    writer = PdfWriter()
+    writer.add_blank_page(width=w, height=h)
+    buf = BytesIO()
+    writer.write(buf)
+    buf.seek(0)
+    return buf
+
+
+def test_juntar_pdfs_respeita_ordem(tmp_path):
+    app = create_app()
+    app.config['UPLOAD_FOLDER'] = tmp_path
+    with app.app_context():
+        f1 = FileStorage(stream=_pdf(10, 20), filename="a.pdf")
+        f2 = FileStorage(stream=_pdf(30, 40), filename="b.pdf")
+        output = merge_service.juntar_pdfs([f2, f1])
+        reader = PdfReader(output)
+        w0 = float(reader.pages[0].mediabox.width)
+        h0 = float(reader.pages[0].mediabox.height)
+        w1 = float(reader.pages[1].mediabox.width)
+        h1 = float(reader.pages[1].mediabox.height)
+        assert (w0, h0) == (30, 40)
+        assert (w1, h1) == (10, 20)


### PR DESCRIPTION
## Summary
- permite mover arquivos na lista da interface drag'n'drop
- mostra botões de subir e descer ao lado de cada item
- reutiliza `.icon-btn` para estilizar os controles e cria regra `.actions`
- avisa no formulário de junção que a ordem pode ser alterada
- adiciona teste garantindo a ordem ao juntar PDFs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68657e06828883218637195da4d06c12