### PR TITLE
Remove required attribute on compress input

### DIFF
--- a/app/templates/compress.html
+++ b/app/templates/compress.html
@@ -23,7 +23,7 @@
             <form action="/api/compress" method="post" enctype="multipart/form-data">
                 <label>Escolha um arquivo PDF:</label>
                 <div id="dropzone" class="dropzone">
-                    <input type="file" name="file" id="file-input" accept=".pdf" required>
+                    <input type="file" name="file" id="file-input" accept=".pdf">
                     Arraste o arquivo aqui ou clique para selecionar
                 </div>
                 <ul id="lista-arquivos"></ul>


### PR DESCRIPTION
## Summary
- remove `required` from file input in compress form so custom error handling can execute

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68666df19b7c83219ec81b50d653d574