### PR TITLE
Add endpoint tests for merge and split

### DIFF
--- a/tests/test_merge_route.py
+++ b/tests/test_merge_route.py
@@ -1,0 +1,57 @@
+from io import BytesIO
+from PyPDF2 import PdfWriter
+from app import create_app
+
+
+def _simple_pdf():
+    writer = PdfWriter()
+    writer.add_blank_page(width=10, height=10)
+    buf = BytesIO()
+    writer.write(buf)
+    buf.seek(0)
+    return buf
+
+
+def test_merge_endpoint_success(monkeypatch, tmp_path):
+    app = create_app()
+    app.config['UPLOAD_FOLDER'] = tmp_path
+    app.config['WTF_CSRF_ENABLED'] = False
+    client = app.test_client()
+
+    def fake_merge(files):
+        out = tmp_path / "merged.pdf"
+        out.write_bytes(b"PDF")
+        return str(out)
+
+    monkeypatch.setattr('app.routes.merge.juntar_pdfs', fake_merge)
+    monkeypatch.setattr('os.remove', lambda *args, **kwargs: None)
+
+    data = {
+        'files': [
+            (_simple_pdf(), 'a.pdf'),
+            (_simple_pdf(), 'b.pdf'),
+        ]
+    }
+    resp = client.post('/api/merge', data=data, content_type='multipart/form-data')
+    assert resp.status_code == 200
+
+
+def test_merge_endpoint_requires_files():
+    app = create_app()
+    app.config['WTF_CSRF_ENABLED'] = False
+    client = app.test_client()
+    resp = client.post('/api/merge', data={}, content_type='multipart/form-data')
+    assert resp.status_code == 400
+    assert resp.get_json() == {'error': 'Nenhum arquivo enviado.'}
+
+
+def test_merge_endpoint_needs_multiple_files():
+    app = create_app()
+    app.config['WTF_CSRF_ENABLED'] = False
+    client = app.test_client()
+    data = {'files': [(BytesIO(b'x'), 'single.pdf')]}
+    resp = client.post('/api/merge', data=data, content_type='multipart/form-data')
+    assert resp.status_code == 400
+    assert resp.get_json() == {'error': 'Envie pelo menos dois arquivos PDF.'}
+
+

--- a/tests/test_split_route.py
+++ b/tests/test_split_route.py
@@ -1,0 +1,53 @@
+from io import BytesIO
+from PyPDF2 import PdfWriter
+from app import create_app
+
+
+def _simple_pdf():
+    writer = PdfWriter()
+    writer.add_blank_page(width=10, height=10)
+    buf = BytesIO()
+    writer.write(buf)
+    buf.seek(0)
+    return buf
+
+
+def test_split_endpoint_success(monkeypatch, tmp_path):
+    app = create_app()
+    app.config['UPLOAD_FOLDER'] = tmp_path
+    app.config['WTF_CSRF_ENABLED'] = False
+    client = app.test_client()
+
+    def fake_split(file):
+        p1 = tmp_path / "p1.pdf"
+        p2 = tmp_path / "p2.pdf"
+        p1.write_bytes(b"A")
+        p2.write_bytes(b"B")
+        return [str(p1), str(p2)]
+
+    monkeypatch.setattr('app.routes.split.dividir_pdf', fake_split)
+    monkeypatch.setattr('os.remove', lambda *args, **kwargs: None)
+
+    data = {'file': (_simple_pdf(), 'doc.pdf')}
+    resp = client.post('/api/split', data=data, content_type='multipart/form-data')
+    assert resp.status_code == 200
+
+
+def test_split_endpoint_requires_file():
+    app = create_app()
+    app.config['WTF_CSRF_ENABLED'] = False
+    client = app.test_client()
+    resp = client.post('/api/split', data={}, content_type='multipart/form-data')
+    assert resp.status_code == 400
+    assert resp.get_json() == {'error': 'Nenhum arquivo enviado.'}
+
+
+def test_split_endpoint_requires_filename():
+    app = create_app()
+    app.config['WTF_CSRF_ENABLED'] = False
+    client = app.test_client()
+    data = {'file': (_simple_pdf(), '')}
+    resp = client.post('/api/split', data=data, content_type='multipart/form-data')
+    assert resp.status_code == 400
+    assert resp.get_json() == {'error': 'Nenhum arquivo selecionado.'}
+


### PR DESCRIPTION
## Summary
- add tests for /api/merge endpoint
- add tests for /api/split endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68666df7b2708321ac4b3f7db3ee50cb