### PR TITLE
Fix preview modal appearance timing

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -43,6 +43,7 @@ function fecharPreview() {
   const modal = document.getElementById('preview-modal');
   if (modal) {
     modal.classList.add('hidden');
+    modal.style.display = 'none';
   }
   modificacoesPorArquivo.length = 0;
 }
@@ -88,6 +89,7 @@ function mostrarPreview(arquivos, aoConfirmar) {
     aoConfirmar();
   };
   modal.classList.remove('hidden');
+  modal.style.display = 'flex';
 }
 
 function rotacionarArquivo(index) {

--- a/app/templates/compress.html
+++ b/app/templates/compress.html
@@ -36,7 +36,7 @@
 <div id="progress-container" class="progress-container">
     <div id="progress-bar" class="progress-bar"></div>
 </div>
-        <div id="preview-modal" class="hidden">
+        <div id="preview-modal" class="hidden" style="display:none;">
             <div class="modal-content">
                 <button id="preview-close" class="close-btn" type="button">&times;</button>
                 <ul id="preview-list"></ul>

--- a/app/templates/converter.html
+++ b/app/templates/converter.html
@@ -33,7 +33,7 @@
         <div id="progress-container" class="progress-container">
             <div id="progress-bar" class="progress-bar"></div>
         </div>
-        <div id="preview-modal" class="hidden">
+        <div id="preview-modal" class="hidden" style="display:none;">
             <div class="modal-content">
                 <button id="preview-close" class="close-btn" type="button">&times;</button>
                 <ul id="preview-list"></ul>

--- a/app/templates/merge.html
+++ b/app/templates/merge.html
@@ -34,7 +34,7 @@
         <div id="progress-container" class="progress-container">
             <div id="progress-bar" class="progress-bar"></div>
         </div>
-        <div id="preview-modal" class="hidden">
+        <div id="preview-modal" class="hidden" style="display:none;">
             <div class="modal-content">
                 <button id="preview-close" class="close-btn" type="button">&times;</button>
                 <ul id="preview-list"></ul>

--- a/app/templates/split.html
+++ b/app/templates/split.html
@@ -33,7 +33,7 @@
         <div id="progress-container" class="progress-container">
             <div id="progress-bar" class="progress-bar"></div>
         </div>
-        <div id="preview-modal" class="hidden">
+        <div id="preview-modal" class="hidden" style="display:none;">
             <div class="modal-content">
                 <button id="preview-close" class="close-btn" type="button">&times;</button>
                 <ul id="preview-list"></ul>


### PR DESCRIPTION
## Summary
- keep preview modal hidden with inline style until triggered by user
- explicitly set display when showing or hiding the modal

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bce81fa4c8321b0a47ee685838b04