### PR TITLE
Fix preview modal markup

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -397,6 +397,13 @@ footer {
     margin-left: 6px;
 }
 
+.modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+    margin-top: 15px;
+}
+
 @media (max-width: 600px) {
     header h1 {
         font-size: 1.4rem;

--- a/app/templates/compress.html
+++ b/app/templates/compress.html
@@ -36,12 +36,14 @@
 <div id="progress-container" class="progress-container">
     <div id="progress-bar" class="progress-bar"></div>
 </div>
-        <div id="preview-modal" class="hidden" style="display:none;">
+        <div id="preview-modal" class="hidden">
             <div class="modal-content">
-                <button id="preview-close" class="close-btn" type="button">&times;</button>
+                <button id="preview-close" class="close-btn" aria-label="Fechar">&times;</button>
                 <ul id="preview-list"></ul>
-                <button id="preview-cancel" type="button">Cancelar</button>
-                <button id="preview-confirm" type="button">Confirmar</button>
+                <div class="modal-actions">
+                    <button id="preview-cancel">Cancelar</button>
+                    <button id="preview-confirm">Confirmar</button>
+                </div>
             </div>
         </div>
     </main>

--- a/app/templates/converter.html
+++ b/app/templates/converter.html
@@ -33,12 +33,14 @@
         <div id="progress-container" class="progress-container">
             <div id="progress-bar" class="progress-bar"></div>
         </div>
-        <div id="preview-modal" class="hidden" style="display:none;">
+        <div id="preview-modal" class="hidden">
             <div class="modal-content">
-                <button id="preview-close" class="close-btn" type="button">&times;</button>
+                <button id="preview-close" class="close-btn" aria-label="Fechar">&times;</button>
                 <ul id="preview-list"></ul>
-                <button id="preview-cancel" type="button">Cancelar</button>
-                <button id="preview-confirm" type="button">Confirmar</button>
+                <div class="modal-actions">
+                    <button id="preview-cancel">Cancelar</button>
+                    <button id="preview-confirm">Confirmar</button>
+                </div>
             </div>
         </div>
     </main>

--- a/app/templates/merge.html
+++ b/app/templates/merge.html
@@ -34,12 +34,14 @@
         <div id="progress-container" class="progress-container">
             <div id="progress-bar" class="progress-bar"></div>
         </div>
-        <div id="preview-modal" class="hidden" style="display:none;">
+        <div id="preview-modal" class="hidden">
             <div class="modal-content">
-                <button id="preview-close" class="close-btn" type="button">&times;</button>
+                <button id="preview-close" class="close-btn" aria-label="Fechar">&times;</button>
                 <ul id="preview-list"></ul>
-                <button id="preview-cancel" type="button">Cancelar</button>
-                <button id="preview-confirm" type="button">Confirmar</button>
+                <div class="modal-actions">
+                    <button id="preview-cancel">Cancelar</button>
+                    <button id="preview-confirm">Confirmar</button>
+                </div>
             </div>
         </div>
     </main>

--- a/app/templates/split.html
+++ b/app/templates/split.html
@@ -33,12 +33,14 @@
         <div id="progress-container" class="progress-container">
             <div id="progress-bar" class="progress-bar"></div>
         </div>
-        <div id="preview-modal" class="hidden" style="display:none;">
+        <div id="preview-modal" class="hidden">
             <div class="modal-content">
-                <button id="preview-close" class="close-btn" type="button">&times;</button>
+                <button id="preview-close" class="close-btn" aria-label="Fechar">&times;</button>
                 <ul id="preview-list"></ul>
-                <button id="preview-cancel" type="button">Cancelar</button>
-                <button id="preview-confirm" type="button">Confirmar</button>
+                <div class="modal-actions">
+                    <button id="preview-cancel">Cancelar</button>
+                    <button id="preview-confirm">Confirmar</button>
+                </div>
             </div>
         </div>
     </main>


### PR DESCRIPTION
## Summary
- structure preview modal HTML consistently across templates
- style action buttons in modal

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bd90a36c08321b5d6a95021eb1912