### PR TITLE
Improve preview modal handling

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -394,8 +394,36 @@ document.addEventListener('DOMContentLoaded', () => {
       list: fileList,
       extensions: exts,
       multiple: allowMultiple,
-      onChange: () => {}
+      onChange: () => {
+        const files = dz.getFiles();
+        const modal = document.getElementById('preview-modal');
+        if (modal) {
+          if (files.length > 0) {
+            modal.classList.remove('hidden');
+          } else {
+            modal.classList.add('hidden');
+          }
+        }
+      }
     });
+
+    const cancelBtn  = document.getElementById('preview-cancel');
+    const confirmBtn = document.getElementById('preview-confirm');
+
+    if (cancelBtn) {
+      cancelBtn.addEventListener('click', () => {
+        const modal = document.getElementById('preview-modal');
+        if (modal) modal.classList.add('hidden');
+        if (dz) dz.clear();
+      });
+    }
+
+    if (confirmBtn) {
+      confirmBtn.addEventListener('click', () => {
+        const modal = document.getElementById('preview-modal');
+        if (modal) modal.classList.add('hidden');
+      });
+    }
   }
 
   if (converterBtn && fileInput) {


### PR DESCRIPTION
## Summary
- show preview modal automatically when files are added to the dropzone
- hide the preview modal and clear files when cancelling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bf027f1408321897d5a25944a2c25