### PR TITLE
Add PDF preview in modal

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -41,22 +41,39 @@ const modificacoesPorArquivo = [];
 
 function fecharPreview() {
   const modal = document.getElementById('preview-modal');
+  const previewFrame = document.getElementById('pdf-frame');
+  const previewContainer = document.getElementById('pdf-preview');
   if (modal) {
     modal.classList.add('hidden');
     modal.style.display = 'none';
   }
+  if (previewFrame && previewFrame.src) {
+    URL.revokeObjectURL(previewFrame.src);
+    previewFrame.src = '';
+  }
+  if (previewContainer) previewContainer.style.display = 'none';
   modificacoesPorArquivo.length = 0;
 }
 
 function mostrarPreview(arquivos, aoConfirmar) {
   const modal = document.getElementById('preview-modal');
   const list = document.getElementById('preview-list');
+  const previewContainer = document.getElementById('pdf-preview');
+  const previewFrame = document.getElementById('pdf-frame');
   if (!modal || !list) {
     aoConfirmar();
     return;
   }
   list.innerHTML = '';
+  if (previewFrame) previewFrame.src = '';
+  if (previewContainer) previewContainer.style.display = 'none';
   modificacoesPorArquivo.length = 0;
+  const pdfFile = arquivos.find(f => f.type === 'application/pdf');
+  if (pdfFile && previewFrame && previewContainer) {
+    const url = URL.createObjectURL(pdfFile);
+    previewFrame.src = url;
+    previewContainer.style.display = 'block';
+  }
   arquivos.forEach((f, i) => {
     modificacoesPorArquivo[i] = {};
     const li = document.createElement('li');

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -381,6 +381,19 @@ footer {
     cursor: pointer;
 }
 
+#pdf-preview {
+    width: 100%;
+    height: 400px;
+    margin-bottom: 1rem;
+    display: none;
+}
+
+#pdf-preview iframe {
+    width: 100%;
+    height: 100%;
+    border: none;
+}
+
 #preview-list {
     list-style: none;
     padding: 0;

--- a/app/templates/compress.html
+++ b/app/templates/compress.html
@@ -39,6 +39,9 @@
         <div id="preview-modal" class="hidden">
             <div class="modal-content">
                 <button id="preview-close" class="close-btn" aria-label="Fechar">&times;</button>
+                <div id="pdf-preview" style="width:100%; height:400px; margin-bottom:1rem; display:none;">
+                    <iframe id="pdf-frame" style="width:100%; height:100%; border:none;" src=""></iframe>
+                </div>
                 <ul id="preview-list"></ul>
                 <div class="modal-actions">
                     <button id="preview-cancel">Cancelar</button>

--- a/app/templates/converter.html
+++ b/app/templates/converter.html
@@ -36,6 +36,9 @@
         <div id="preview-modal" class="hidden">
             <div class="modal-content">
                 <button id="preview-close" class="close-btn" aria-label="Fechar">&times;</button>
+                <div id="pdf-preview" style="width:100%; height:400px; margin-bottom:1rem; display:none;">
+                    <iframe id="pdf-frame" style="width:100%; height:100%; border:none;" src=""></iframe>
+                </div>
                 <ul id="preview-list"></ul>
                 <div class="modal-actions">
                     <button id="preview-cancel">Cancelar</button>

--- a/app/templates/merge.html
+++ b/app/templates/merge.html
@@ -37,6 +37,9 @@
         <div id="preview-modal" class="hidden">
             <div class="modal-content">
                 <button id="preview-close" class="close-btn" aria-label="Fechar">&times;</button>
+                <div id="pdf-preview" style="width:100%; height:400px; margin-bottom:1rem; display:none;">
+                    <iframe id="pdf-frame" style="width:100%; height:100%; border:none;" src=""></iframe>
+                </div>
                 <ul id="preview-list"></ul>
                 <div class="modal-actions">
                     <button id="preview-cancel">Cancelar</button>

--- a/app/templates/split.html
+++ b/app/templates/split.html
@@ -36,6 +36,9 @@
         <div id="preview-modal" class="hidden">
             <div class="modal-content">
                 <button id="preview-close" class="close-btn" aria-label="Fechar">&times;</button>
+                <div id="pdf-preview" style="width:100%; height:400px; margin-bottom:1rem; display:none;">
+                    <iframe id="pdf-frame" style="width:100%; height:100%; border:none;" src=""></iframe>
+                </div>
                 <ul id="preview-list"></ul>
                 <div class="modal-actions">
                     <button id="preview-cancel">Cancelar</button>


### PR DESCRIPTION
## Summary
- show PDF preview in preview modal by embedding iframe
- load PDF file into iframe when showing preview
- add styles for preview container

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bf154cd1c83218a841e163d4a1999