### PR TITLE
Add blob scheme to CSP

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -67,6 +67,7 @@ def create_app():
         'style-src': ["'self'", 'https://fonts.googleapis.com'],
         'img-src': ["'self'", 'data:'],
         'font-src': ["'self'", 'https://fonts.gstatic.com'],
+        'frame-src': ["'self'", 'blob:'],
     }
     Talisman(
         app,


### PR DESCRIPTION
## Summary
- allow `blob:` URLs in `frame-src` CSP to render PDF previews in iframes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c08c49fac8321a4c67a8c633ee2b6