### PR TITLE
Fix preview modal layout

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -503,3 +503,67 @@ footer {
         padding-left: 0;
     }
 }
+/* ======== Modal maior e flexível ======== */
+#preview-modal .modal-content {
+  width: 95vw;             /* quase toda a largura */
+  max-width: 1200px;
+  height: 95vh;            /* quase toda a altura */
+  max-height: 95vh;
+  display: flex;
+  flex-direction: column;
+  padding: 1rem 2rem 2rem;
+  position: relative;
+  overflow: hidden;
+}
+
+/* ======== Lista de arquivos bem pequena ======== */
+#preview-modal #preview-list {
+  flex: 0 0 auto;
+  max-height: 6vh;         /* só 6% da viewport pra liberar espaço */
+  overflow-y: auto;
+  margin-bottom: 0.5rem;
+}
+
+/* ======== Preview de PDF cresce ======== */
+#preview-modal #pdf-preview {
+  /* anula o inline height e deixa o flex crescer */
+  flex: 1 1 auto !important;
+  height: auto         !important;
+  min-height: 0;
+  overflow: auto        !important;
+  margin-bottom: 1rem;
+}
+
+/* ======== Iframe preenche o container ======== */
+#preview-modal #pdf-frame {
+  width: 100%  !important;
+  height: 100% !important;
+}
+
+/* ======== Botões fixos no fim ======== */
+#preview-modal .modal-actions {
+  flex: 0 0 auto;
+  margin-top: auto;
+  display: flex;
+  justify-content: space-between;
+}
+
+/* ======== Botão “×” de fechar ======== */
+#preview-close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: rgba(255,255,255,0.9);
+  color: #333;
+  border: none;
+  font-size: 1.25rem;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  cursor: pointer;
+  z-index: 10;
+}
+
+#preview-close:hover {
+  background: rgba(255,255,255,1);
+}

--- a/app/templates/compress.html
+++ b/app/templates/compress.html
@@ -46,7 +46,7 @@
     </div>
 
     <div id="preview-modal" class="hidden">
-        <div class="preview-content">
+        <div class="modal-content">
             <button id="preview-close" class="preview-close">&times;</button>
             <div id="pdf-preview" style="display:none;">
                 <iframe id="pdf-frame"></iframe>
@@ -55,7 +55,7 @@
                 <img id="img-preview">
             </div>
             <ul id="preview-list"></ul>
-            <div class="preview-actions">
+            <div class="modal-actions">
                 <button id="preview-cancel">Cancelar</button>
                 <button id="preview-confirm">Confirmar</button>
             </div>

--- a/app/templates/converter.html
+++ b/app/templates/converter.html
@@ -43,7 +43,7 @@
     </div>
 
     <div id="preview-modal" class="hidden">
-        <div class="preview-content">
+        <div class="modal-content">
             <button id="preview-close" class="preview-close">&times;</button>
             <div id="pdf-preview" style="display:none;">
                 <iframe id="pdf-frame"></iframe>
@@ -52,7 +52,7 @@
                 <img id="img-preview">
             </div>
             <ul id="preview-list"></ul>
-            <div class="preview-actions">
+            <div class="modal-actions">
                 <button id="preview-cancel">Cancelar</button>
                 <button id="preview-confirm">Confirmar</button>
             </div>

--- a/app/templates/merge.html
+++ b/app/templates/merge.html
@@ -44,7 +44,7 @@
     </div>
 
     <div id="preview-modal" class="hidden">
-        <div class="preview-content">
+        <div class="modal-content">
             <button id="preview-close" class="preview-close">&times;</button>
             <div id="pdf-preview" style="display:none;">
                 <iframe id="pdf-frame"></iframe>
@@ -53,7 +53,7 @@
                 <img id="img-preview">
             </div>
             <ul id="preview-list"></ul>
-            <div class="preview-actions">
+            <div class="modal-actions">
                 <button id="preview-cancel">Cancelar</button>
                 <button id="preview-confirm">Confirmar</button>
             </div>

--- a/app/templates/split.html
+++ b/app/templates/split.html
@@ -43,7 +43,7 @@
     </div>
 
     <div id="preview-modal" class="hidden">
-        <div class="preview-content">
+        <div class="modal-content">
             <button id="preview-close" class="preview-close">&times;</button>
             <div id="pdf-preview" style="display:none;">
                 <iframe id="pdf-frame"></iframe>
@@ -52,7 +52,7 @@
                 <img id="img-preview">
             </div>
             <ul id="preview-list"></ul>
-            <div class="preview-actions">
+            <div class="modal-actions">
                 <button id="preview-cancel">Cancelar</button>
                 <button id="preview-confirm">Confirmar</button>
             </div>


### PR DESCRIPTION
## Summary
- adjust preview modal CSS using `.modal-*` classes
- rename markup to use `.modal-content` and `.modal-actions`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c11effe9c8321bddad3d8bff278a0