### PR TITLE
Improve PDF preview security

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -63,11 +63,12 @@ def create_app():
     # Configurar políticas de segurança HTTP com Flask-Talisman
     csp = {
         'default-src': ["'self'"],
-        'script-src': ["'self'"],
+        'script-src': ["'self'", 'https://cdn.jsdelivr.net'],
         'style-src': ["'self'", 'https://fonts.googleapis.com'],
         'img-src': ["'self'", 'data:'],
         'font-src': ["'self'", 'https://fonts.gstatic.com'],
-        'frame-src': ["'self'", 'blob:'],
+        'connect-src': ["'self'", 'blob:'],
+        'frame-src': ["'self'"]
     }
     Talisman(
         app,

--- a/app/static/fileDropzone.js
+++ b/app/static/fileDropzone.js
@@ -30,8 +30,7 @@
         li.appendChild(span);
 
         const actions = document.createElement('div');
-        actions.style.display = 'flex';
-        actions.style.gap = '4px';
+        actions.className = 'actions';
 
         const up = document.createElement('button');
         up.className = 'icon-btn';

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -38,7 +38,8 @@ function resetarProgresso() {
 }
 
 if (window.pdfjsLib) {
-  pdfjsLib.GlobalWorkerOptions.workerSrc = '/static/pdf.worker.min.js';
+  pdfjsLib.GlobalWorkerOptions.workerSrc =
+    'https://cdn.jsdelivr.net/npm/pdfjs-dist@3.4.120/build/pdf.worker.min.js';
 }
 
 const modificacoesPorArquivo = [];
@@ -79,7 +80,6 @@ function fecharPreview() {
   const imgCont    = document.getElementById('img-preview-container');
 
   modal.classList.add('hidden');
-  modal.style.display = 'none';
 
   clearPdfCanvas();
   if (imgPreview && imgPreview.src) {
@@ -87,8 +87,11 @@ function fecharPreview() {
     imgPreview.src = '';
   }
 
-  if (pdfCont) pdfCont.style.display = 'none';
-  if (imgCont) imgCont.style.display = 'none';
+  if (pdfCont) {
+    pdfCont.classList.add('hidden');
+    pdfCont.classList.remove('preview-flex');
+  }
+  if (imgCont) imgCont.classList.add('hidden');
 
   modificacoesPorArquivo.length = 0;
 }
@@ -108,8 +111,11 @@ function mostrarPreview(arquivos, aoConfirmar) {
   list.innerHTML = '';
   clearPdfCanvas();
   imgPreview.src = '';
-  if (pdfCont) pdfCont.style.display = 'none';
-  if (imgCont) imgCont.style.display = 'none';
+  if (pdfCont) {
+    pdfCont.classList.add('hidden');
+    pdfCont.classList.remove('preview-flex');
+  }
+  if (imgCont) imgCont.classList.add('hidden');
   modificacoesPorArquivo.length = 0;
 
   arquivos.forEach((f, i) => {
@@ -134,11 +140,14 @@ function mostrarPreview(arquivos, aoConfirmar) {
   if (pdfFile) {
     previewPdfUrl = URL.createObjectURL(pdfFile);
     renderPDF(previewPdfUrl);
-    if (pdfCont) pdfCont.style.display = 'block';
+    if (pdfCont) {
+      pdfCont.classList.remove('hidden');
+      pdfCont.classList.add('preview-flex');
+    }
   } else if (arquivos.length === 1 && arquivos[0].type.startsWith('image/')) {
     const url = URL.createObjectURL(arquivos[0]);
     imgPreview.src = url;
-    if (imgCont) imgCont.style.display = 'block';
+    if (imgCont) imgCont.classList.remove('hidden');
   }
 
   document.getElementById('preview-cancel').onclick = fecharPreview;
@@ -149,7 +158,6 @@ function mostrarPreview(arquivos, aoConfirmar) {
   };
 
   modal.classList.remove('hidden');
-  modal.style.display = 'flex';
 }
 
 function rotacionarArquivo(index) {

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -421,7 +421,14 @@ footer {
 }
 
 .hidden {
-    display: none;
+    display: none !important;
+}
+
+.preview-flex {
+    display: flex !important;
+    flex: 1 1 auto !important;
+    min-height: 0 !important;
+    overflow: auto !important;
 }
 
 @media (max-width: 600px) {
@@ -466,7 +473,7 @@ footer {
     }
 }
 /* ======== Modal maior e flexível ======== */
-#preview-modal .modal-content {
+.modal-content {
   background: #fff;
   border-radius: 0.5rem;
   width: 95vw;             /* quase toda a largura */
@@ -481,7 +488,7 @@ footer {
 }
 
 /* ======== Lista de arquivos bem pequena ======== */
-#preview-modal #preview-list {
+#preview-list {
   list-style: none;
   padding: 0;
   flex: 0 0 auto;
@@ -491,7 +498,7 @@ footer {
 }
 
 /* Cada item da lista empilhado e centralizado */
-#preview-modal #preview-list li {
+#preview-list li {
   display: flex !important;       /* garantir flex */
   flex-direction: column !important;
   align-items: center !important;
@@ -500,7 +507,7 @@ footer {
 }
 
 /* Ações centralizadas abaixo do nome */
-#preview-modal #preview-list li > div {
+#preview-list li > div {
   display: flex !important;
   justify-content: center !important;
   gap: 0.5rem;
@@ -508,7 +515,7 @@ footer {
 }
 
 /* ======== Preview de PDF cresce ======== */
-#preview-modal #pdf-preview {
+#pdf-preview {
   /* anula o inline height e deixa o flex crescer */
   flex: 1 1 auto !important;
   height: auto         !important;
@@ -518,14 +525,14 @@ footer {
 }
 
 /* ======== Canvas container ======== */
-#preview-modal #pdf-canvas-container {
+#pdf-canvas-container {
   width: 100%;
   height: 100%;
   overflow: auto;
 }
 
 /* ======== Botões fixos no fim ======== */
-#preview-modal .modal-actions {
+.modal-actions {
   flex: 0 0 auto;
   margin-top: auto;
   display: flex;

--- a/app/templates/_preview_modal.html
+++ b/app/templates/_preview_modal.html
@@ -1,16 +1,19 @@
 <div id="preview-modal" class="hidden">
-    <div class="modal-content">
-        <button id="preview-close" class="preview-close">&times;</button>
-        <div id="pdf-preview" style="display:none;">
-            <div id="pdf-canvas-container"></div>
-        </div>
-        <div id="img-preview-container" style="display:none;">
-            <img id="img-preview">
-        </div>
-        <ul id="preview-list"></ul>
-        <div class="modal-actions">
-            <button id="preview-cancel">Cancelar</button>
-            <button id="preview-confirm">Confirmar</button>
-        </div>
+  <div class="modal-content">
+    <button id="preview-close">&times;</button>
+    <ul id="preview-list" class="hidden"></ul>
+
+    <div id="pdf-preview" class="hidden preview-flex">
+      <div id="pdf-canvas-container"></div>
     </div>
+
+    <div id="img-preview-container" class="hidden">
+      <img id="img-preview">
+    </div>
+
+    <div class="modal-actions">
+      <button id="preview-cancel">Cancelar</button>
+      <button id="preview-confirm">Confirmar</button>
+    </div>
+  </div>
 </div>

--- a/app/templates/compress.html
+++ b/app/templates/compress.html
@@ -47,7 +47,7 @@
 
     {% include '_preview_modal.html' %}
 
-    <script src="/static/pdf.min.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.4.120/build/pdf.min.js" defer></script>
     <script src="/static/fileDropzone.js" defer></script>
     <script src="/static/script.js" defer></script>
 </body>

--- a/app/templates/converter.html
+++ b/app/templates/converter.html
@@ -44,7 +44,7 @@
 
     {% include '_preview_modal.html' %}
 
-    <script src="/static/pdf.min.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.4.120/build/pdf.min.js" defer></script>
     <script src="/static/fileDropzone.js" defer></script>
     <script src="/static/script.js" defer></script>
 </body>

--- a/app/templates/merge.html
+++ b/app/templates/merge.html
@@ -45,7 +45,7 @@
 
     {% include '_preview_modal.html' %}
 
-    <script src="/static/pdf.min.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.4.120/build/pdf.min.js" defer></script>
     <script src="/static/fileDropzone.js" defer></script>
     <script src="/static/script.js" defer></script>
 </body>

--- a/app/templates/split.html
+++ b/app/templates/split.html
@@ -44,7 +44,7 @@
 
     {% include '_preview_modal.html' %}
 
-    <script src="/static/pdf.min.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.4.120/build/pdf.min.js" defer></script>
     <script src="/static/fileDropzone.js" defer></script>
     <script src="/static/script.js" defer></script>
 </body>


### PR DESCRIPTION
## Summary
- add preview-flex helper class and clean up modal HTML
- refactor script to toggle classes instead of inline styles
- load pdf.js from CDN and update CSP rules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d058787e0832187b9b30c91fb347d