### PR TITLE
Fix PDF.js worker path

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -38,8 +38,7 @@ function resetarProgresso() {
 }
 
 if (window.pdfjsLib) {
-  pdfjsLib.GlobalWorkerOptions.workerSrc =
-    'https://cdn.jsdelivr.net/npm/pdfjs-dist@3.4.120/build/pdf.worker.min.js';
+  pdfjsLib.GlobalWorkerOptions.workerSrc = '/static/pdf.worker.min.js';
 }
 
 const modificacoesPorArquivo = [];


### PR DESCRIPTION
## Summary
- set pdfjsLib worker script to local static path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d1ae144c48321b9cd676b5a93d140