### PR TITLE
Fix CSP for PDF preview

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -68,7 +68,8 @@ def create_app():
         'img-src': ["'self'", 'data:'],
         'font-src': ["'self'", 'https://fonts.gstatic.com'],
         'connect-src': ["'self'", 'blob:'],
-        'frame-src': ["'self'"]
+        'worker-src': ["'self'", 'blob:'],
+        'frame-src': ["'self'", 'blob:']
     }
     Talisman(
         app,

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -9,15 +9,17 @@ function mostrarMensagem(mensagem, tipo = 'sucesso') {
   const msgDiv = document.getElementById('mensagem-feedback');
   if (!msgDiv) return;
   msgDiv.textContent = mensagem;
-  msgDiv.className = tipo;
-  msgDiv.style.display = 'block';
-  setTimeout(() => { msgDiv.style.display = 'none'; }, 5000);
+  msgDiv.classList.remove('sucesso', 'erro', 'hidden');
+  msgDiv.classList.add(tipo);
+  setTimeout(() => { msgDiv.classList.add('hidden'); }, 5000);
 }
 
 /* Loading Spinner */
 function mostrarLoading(mostrar = true) {
   const loadingDiv = document.getElementById('loading-spinner');
-  if (loadingDiv) loadingDiv.style.display = mostrar ? 'block' : 'none';
+  if (loadingDiv) {
+    loadingDiv.classList[mostrar ? 'remove' : 'add']('hidden');
+  }
 }
 
 /* Progress Bar */
@@ -25,7 +27,7 @@ function atualizarProgresso(percent) {
   const container = document.getElementById('progress-container');
   const bar = document.getElementById('progress-bar');
   if (!container || !bar) return;
-  container.style.display = 'block';
+  container.classList.remove('hidden');
   bar.style.width = percent + '%';
 }
 
@@ -34,7 +36,7 @@ function resetarProgresso() {
   const bar = document.getElementById('progress-bar');
   if (!container || !bar) return;
   bar.style.width = '0%';
-  container.style.display = 'none';
+  container.classList.add('hidden');
 }
 
 if (window.pdfjsLib) {

--- a/app/templates/compress.html
+++ b/app/templates/compress.html
@@ -31,9 +31,9 @@
                 <button id="preview-btn" type="button">Visualizar</button>
             </form>
         </section>
-<div id="mensagem-feedback"></div>
-<div id="loading-spinner">Processando...</div>
-<div id="progress-container" class="progress-container">
+<div id="mensagem-feedback" class="hidden"></div>
+<div id="loading-spinner" class="hidden">Processando...</div>
+<div id="progress-container" class="progress-container hidden">
     <div id="progress-bar" class="progress-bar"></div>
 </div>
     </main>
@@ -47,7 +47,10 @@
 
     {% include '_preview_modal.html' %}
 
-    <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.4.120/build/pdf.min.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.4.120/build/pdf.min.js"></script>
+    <script>
+      pdfjsLib.GlobalWorkerOptions.workerSrc = '/static/pdf.worker.min.js';
+    </script>
     <script src="/static/fileDropzone.js" defer></script>
     <script src="/static/script.js" defer></script>
 </body>

--- a/app/templates/converter.html
+++ b/app/templates/converter.html
@@ -28,9 +28,9 @@
             <button id="converter-btn">Converter Todos</button>
             <button id="preview-btn" type="button">Visualizar</button>
         </section>
-        <div id="mensagem-feedback"></div>
-        <div id="loading-spinner">Processando...</div>
-        <div id="progress-container" class="progress-container">
+        <div id="mensagem-feedback" class="hidden"></div>
+        <div id="loading-spinner" class="hidden">Processando...</div>
+        <div id="progress-container" class="progress-container hidden">
             <div id="progress-bar" class="progress-bar"></div>
         </div>
     </main>
@@ -44,7 +44,10 @@
 
     {% include '_preview_modal.html' %}
 
-    <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.4.120/build/pdf.min.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.4.120/build/pdf.min.js"></script>
+    <script>
+      pdfjsLib.GlobalWorkerOptions.workerSrc = '/static/pdf.worker.min.js';
+    </script>
     <script src="/static/fileDropzone.js" defer></script>
     <script src="/static/script.js" defer></script>
 </body>

--- a/app/templates/merge.html
+++ b/app/templates/merge.html
@@ -29,9 +29,9 @@
             <button id="merge-btn">Juntar PDFs</button>
             <button id="preview-btn" type="button">Visualizar</button>
         </section>
-        <div id="mensagem-feedback"></div>
-        <div id="loading-spinner">Processando...</div>
-        <div id="progress-container" class="progress-container">
+        <div id="mensagem-feedback" class="hidden"></div>
+        <div id="loading-spinner" class="hidden">Processando...</div>
+        <div id="progress-container" class="progress-container hidden">
             <div id="progress-bar" class="progress-bar"></div>
         </div>
     </main>
@@ -45,7 +45,10 @@
 
     {% include '_preview_modal.html' %}
 
-    <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.4.120/build/pdf.min.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.4.120/build/pdf.min.js"></script>
+    <script>
+      pdfjsLib.GlobalWorkerOptions.workerSrc = '/static/pdf.worker.min.js';
+    </script>
     <script src="/static/fileDropzone.js" defer></script>
     <script src="/static/script.js" defer></script>
 </body>

--- a/app/templates/split.html
+++ b/app/templates/split.html
@@ -28,9 +28,9 @@
             <button id="split-btn">Dividir</button>
             <button id="preview-btn" type="button">Visualizar</button>
         </section>
-        <div id="mensagem-feedback"></div>
-        <div id="loading-spinner">Processando...</div>
-        <div id="progress-container" class="progress-container">
+        <div id="mensagem-feedback" class="hidden"></div>
+        <div id="loading-spinner" class="hidden">Processando...</div>
+        <div id="progress-container" class="progress-container hidden">
             <div id="progress-bar" class="progress-bar"></div>
         </div>
     </main>
@@ -44,7 +44,10 @@
 
     {% include '_preview_modal.html' %}
 
-    <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.4.120/build/pdf.min.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.4.120/build/pdf.min.js"></script>
+    <script>
+      pdfjsLib.GlobalWorkerOptions.workerSrc = '/static/pdf.worker.min.js';
+    </script>
     <script src="/static/fileDropzone.js" defer></script>
     <script src="/static/script.js" defer></script>
 </body>


### PR DESCRIPTION
## Summary
- avoid inline style display toggling
- preload PDF.js and worker before scripts
- allow workers and blob usage in CSP
- mark feedback/loading/progress elements hidden by default

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d1bcdeec88321a540aa50357dbe6e