### PR TITLE
Update CSP script-src for CDN

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -63,7 +63,7 @@ def create_app():
     # Configurar políticas de segurança HTTP com Flask-Talisman
     csp = {
         'default-src': ["'self'"],
-        'script-src': ["'self'"],
+        'script-src': ["'self'", 'https://cdn.jsdelivr.net'],
         'style-src': ["'self'", 'https://fonts.googleapis.com'],
         'img-src': ["'self'", 'data:'],
         'font-src': ["'self'", 'https://fonts.gstatic.com'],


### PR DESCRIPTION
## Summary
- extend Flask-Talisman CSP configuration to allow scripts from jsDelivr CDN

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d1fc04e008321ba5a6182886ab5bc