### PR TITLE
Update templates to include PDF.js CDN

### DIFF
--- a/app/templates/compress.html
+++ b/app/templates/compress.html
@@ -44,6 +44,8 @@
         <a href="/split"><button>Dividir PDF</button></a>
     </div>
 
+    <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.9.179/build/pdf.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.9.179/build/pdf.worker.min.js"></script>
     <script src="/static/fileDropzone.js" defer></script>
     <script src="/static/script.js" defer></script>
 </body>

--- a/app/templates/converter.html
+++ b/app/templates/converter.html
@@ -41,6 +41,8 @@
         <a href="/compress"><button>Comprimir PDF</button></a>
     </div>
 
+    <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.9.179/build/pdf.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.9.179/build/pdf.worker.min.js"></script>
     <script src="/static/fileDropzone.js" defer></script>
     <script src="/static/script.js" defer></script>
 </body>

--- a/app/templates/merge.html
+++ b/app/templates/merge.html
@@ -42,6 +42,8 @@
         <a href="/compress"><button>Comprimir PDF</button></a>
     </div>
 
+    <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.9.179/build/pdf.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.9.179/build/pdf.worker.min.js"></script>
     <script src="/static/fileDropzone.js" defer></script>
     <script src="/static/script.js" defer></script>
 </body>

--- a/app/templates/split.html
+++ b/app/templates/split.html
@@ -41,6 +41,8 @@
         <a href="/compress"><button>Comprimir PDF</button></a>
     </div>
 
+    <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.9.179/build/pdf.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.9.179/build/pdf.worker.min.js"></script>
     <script src="/static/fileDropzone.js" defer></script>
     <script src="/static/script.js" defer></script>
 </body>


### PR DESCRIPTION
## Summary
- add PDF.js `pdf.min.js` and `pdf.worker.min.js` from jsDelivr CDN in templates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d1fc0e448832182ff1629b566804a