### PR TITLE
Set PDF.js worker src in main JS

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -1,4 +1,9 @@
 
+if (window.pdfjsLib) {
+  pdfjsLib.GlobalWorkerOptions.workerSrc =
+    'https://cdn.jsdelivr.net/npm/pdfjs-dist@3.9.179/build/pdf.worker.min.js';
+}
+
 function getCSRFToken() {
   const meta = document.querySelector('meta[name="csrf-token"]');
   return meta ? meta.getAttribute('content') : '';


### PR DESCRIPTION
## Summary
- configure pdfjs worker source in `static/script.js`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d1fc17f7083218fca990a2cf3c4e9