### PR TITLE
Fix PDF.js version mismatch

### DIFF
--- a/app/templates/compress.html
+++ b/app/templates/compress.html
@@ -47,10 +47,7 @@
 
     {% include '_preview_modal.html' %}
 
-    <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.4.120/build/pdf.min.js"></script>
-    <script>
-      pdfjsLib.GlobalWorkerOptions.workerSrc = '/static/pdf.worker.min.js';
-    </script>
+    <script src="/static/pdf.min.js"></script>
     <script src="/static/fileDropzone.js" defer></script>
     <script src="/static/script.js" defer></script>
 </body>

--- a/app/templates/converter.html
+++ b/app/templates/converter.html
@@ -44,10 +44,7 @@
 
     {% include '_preview_modal.html' %}
 
-    <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.4.120/build/pdf.min.js"></script>
-    <script>
-      pdfjsLib.GlobalWorkerOptions.workerSrc = '/static/pdf.worker.min.js';
-    </script>
+    <script src="/static/pdf.min.js"></script>
     <script src="/static/fileDropzone.js" defer></script>
     <script src="/static/script.js" defer></script>
 </body>

--- a/app/templates/merge.html
+++ b/app/templates/merge.html
@@ -45,10 +45,7 @@
 
     {% include '_preview_modal.html' %}
 
-    <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.4.120/build/pdf.min.js"></script>
-    <script>
-      pdfjsLib.GlobalWorkerOptions.workerSrc = '/static/pdf.worker.min.js';
-    </script>
+    <script src="/static/pdf.min.js"></script>
     <script src="/static/fileDropzone.js" defer></script>
     <script src="/static/script.js" defer></script>
 </body>

--- a/app/templates/split.html
+++ b/app/templates/split.html
@@ -44,10 +44,7 @@
 
     {% include '_preview_modal.html' %}
 
-    <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.4.120/build/pdf.min.js"></script>
-    <script>
-      pdfjsLib.GlobalWorkerOptions.workerSrc = '/static/pdf.worker.min.js';
-    </script>
+    <script src="/static/pdf.min.js"></script>
     <script src="/static/fileDropzone.js" defer></script>
     <script src="/static/script.js" defer></script>
 </body>


### PR DESCRIPTION
## Summary
- align PDF.js library version with the bundled worker
- remove inline worker configuration to satisfy CSP

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d217344d08321a8c0ed577a1fb410