### PR TITLE
Add viewer blueprint and fix static references

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -90,11 +90,13 @@ def create_app():
     from .routes.merge import merge_bp
     from .routes.split import split_bp
     from .routes.compress import compress_bp
+    from .routes.viewer import viewer_bp
 
     app.register_blueprint(converter_bp, url_prefix='/api')
     app.register_blueprint(merge_bp, url_prefix='/api')
     app.register_blueprint(split_bp, url_prefix='/api')
     app.register_blueprint(compress_bp, url_prefix='/api')
+    app.register_blueprint(viewer_bp)
 
     # Rotas das páginas do frontend
     @app.route('/')

--- a/app/routes/viewer.py
+++ b/app/routes/viewer.py
@@ -1,0 +1,18 @@
+from flask import Blueprint, render_template, current_app, send_from_directory, abort
+import os
+
+viewer_bp = Blueprint('viewer', __name__, url_prefix='/viewer')
+
+@viewer_bp.route('/<path:filename>')
+def show_pdf(filename):
+    upload_folder = current_app.config['UPLOAD_FOLDER']
+    file_path = os.path.join(upload_folder, filename)
+    if not os.path.isfile(file_path):
+        abort(404)
+    return render_template('viewer.html', filename=filename)
+
+@viewer_bp.route('/raw/<path:filename>')
+def get_pdf(filename):
+    upload_folder = current_app.config['UPLOAD_FOLDER']
+    return send_from_directory(upload_folder, filename)
+

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -54,18 +54,21 @@ function clearPdfCanvas() {
 
 function renderPDF(url) {
   const container = document.getElementById('pdf-canvas-container');
-    for (let pageNum = 1; pageNum <= pdf.numPages; pageNum++) {
-      pdf.getPage(pageNum).then(page => {
-        const viewport = page.getViewport({ scale: 1.0 });
-        const canvas = document.createElement('canvas');
-        canvas.width = viewport.width;
-        canvas.height = viewport.height;
-        container.appendChild(canvas);
-        const context = canvas.getContext('2d');
-        page.render({ canvasContext: context, viewport });
-      });
-    }
-  });
+  pdfjsLib.getDocument(url).promise
+    .then(pdf => {
+      for (let pageNum = 1; pageNum <= pdf.numPages; pageNum++) {
+        pdf.getPage(pageNum).then(page => {
+          const viewport = page.getViewport({ scale: 1.0 });
+          const canvas = document.createElement('canvas');
+          canvas.width = viewport.width;
+          canvas.height = viewport.height;
+          container.appendChild(canvas);
+          const context = canvas.getContext('2d');
+          page.render({ canvasContext: context, viewport });
+        });
+      }
+    })
+    .catch(err => console.error('Erro ao renderizar PDF:', err));
 }
 
 function renderImage(url) {

--- a/app/templates/_preview_modal.html
+++ b/app/templates/_preview_modal.html
@@ -34,7 +34,7 @@
 
 <!-- 3) Scripts auxiliares -->
 <script src="{{ url_for('static', filename='js/pdf-config.js') }}"></script>
-<script src="{{ url_for('static', filename='js/fileDropzone.js') }}"></script>
+<script src="{{ url_for('static', filename='fileDropzone.js') }}"></script>
 
 <!-- 4) Seu script principal de preview -->
-<script src="{{ url_for('static', filename='js/script.js') }}"></script>
+<script src="{{ url_for('static', filename='script.js') }}"></script>

--- a/app/templates/compress.html
+++ b/app/templates/compress.html
@@ -51,6 +51,6 @@
     <!-- Scripts: PDF.js, configuração do worker, dropzone e lógica principal -->
     <script src="{{ url_for('static', filename='pdfjs/pdf.min.js') }}"></script>
     <script src="{{ url_for('static', filename='js/pdf-config.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/fileDropzone.js') }}" defer></script>
-    <script src="{{ url_for('static', filename='js/script.js') }}" defer></script>
+    <script src="{{ url_for('static', filename='fileDropzone.js') }}" defer></script>
+    <script src="{{ url_for('static', filename='script.js') }}" defer></script>
 </body></html>

--- a/app/templates/converter.html
+++ b/app/templates/converter.html
@@ -48,6 +48,6 @@
     <!-- Scripts: PDF.js, configuração do worker, dropzone e lógica principal -->
     <script src="{{ url_for('static', filename='pdfjs/pdf.min.js') }}"></script>
     <script src="{{ url_for('static', filename='js/pdf-config.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/fileDropzone.js') }}" defer></script>
-    <script src="{{ url_for('static', filename='js/script.js') }}" defer></script>
+    <script src="{{ url_for('static', filename='fileDropzone.js') }}" defer></script>
+    <script src="{{ url_for('static', filename='script.js') }}" defer></script>
 </body></html>

--- a/app/templates/merge.html
+++ b/app/templates/merge.html
@@ -49,6 +49,6 @@
     <!-- Scripts: PDF.js, configuração do worker, dropzone e lógica principal -->
     <script src="{{ url_for('static', filename='pdfjs/pdf.min.js') }}"></script>
     <script src="{{ url_for('static', filename='js/pdf-config.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/fileDropzone.js') }}" defer></script>
-    <script src="{{ url_for('static', filename='js/script.js') }}" defer></script>
+    <script src="{{ url_for('static', filename='fileDropzone.js') }}" defer></script>
+    <script src="{{ url_for('static', filename='script.js') }}" defer></script>
 </body></html>

--- a/app/templates/split.html
+++ b/app/templates/split.html
@@ -53,6 +53,6 @@
     <!-- Scripts: PDF.js, configuração do worker, dropzone e lógica principal -->
     <script src="{{ url_for('static', filename='pdfjs/pdf.min.js') }}"></script>
     <script src="{{ url_for('static', filename='js/pdf-config.js') }}" defer></script>
-    <script src="{{ url_for('static', filename='js/fileDropzone.js') }}" defer></script>
-    <script src="{{ url_for('static', filename='js/script.js') }}" defer></script>
+    <script src="{{ url_for('static', filename='fileDropzone.js') }}" defer></script>
+    <script src="{{ url_for('static', filename='script.js') }}" defer></script>
 </body></html>

--- a/app/templates/viewer.html
+++ b/app/templates/viewer.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+  <meta charset="UTF-8">
+  <title>Visualizador de PDF</title>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.4.456/pdf.min.js"></script>
+  <style>
+    canvas { border: 1px solid #ddd; display: block; margin: 0 auto; }
+    #controls { text-align: center; margin-bottom: 10px; }
+  </style>
+</head>
+<body>
+  <div id="controls">
+    <button id="prev">‹ Anterior</button>
+    <span>Página <span id="page_num"></span> de <span id="page_count"></span></span>
+    <button id="next">Próxima ›</button>
+  </div>
+  <canvas id="pdf-render"></canvas>
+
+  <script>
+    const url = "{{ url_for('viewer.get_pdf', filename=filename) }}";
+
+    let pdfDoc = null,
+        pageNum = 1,
+        isRendering = false,
+        pendingPage = null;
+
+    const scale = 1.5,
+          canvas = document.getElementById('pdf-render'),
+          ctx = canvas.getContext('2d');
+
+    function renderPage(num) {
+      isRendering = true;
+      pdfDoc.getPage(num).then(page => {
+        const viewport = page.getViewport({ scale });
+        canvas.height = viewport.height;
+        canvas.width  = viewport.width;
+        return page.render({ canvasContext: ctx, viewport }).promise;
+      }).then(() => {
+        isRendering = false;
+        if (pendingPage !== null) {
+          renderPage(pendingPage);
+          pendingPage = null;
+        }
+      });
+      document.getElementById('page_num').textContent = num;
+    }
+
+    function queueRender(num) {
+      isRendering ? pendingPage = num : renderPage(num);
+    }
+
+    pdfjsLib.getDocument(url).promise
+      .then(doc => {
+        pdfDoc = doc;
+        document.getElementById('page_count').textContent = pdfDoc.numPages;
+        renderPage(pageNum);
+      })
+      .catch(err => console.error('Erro ao carregar PDF:', err));
+
+    document.getElementById('prev').addEventListener('click', () => {
+      if (pageNum <= 1) return;
+      pageNum--;
+      queueRender(pageNum);
+    });
+    document.getElementById('next').addEventListener('click', () => {
+      if (pageNum >= pdfDoc.numPages) return;
+      pageNum++;
+      queueRender(pageNum);
+    });
+  </script>
+</body>
+</html>
+

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -1,0 +1,49 @@
+import os
+from io import BytesIO
+from PyPDF2 import PdfWriter
+from app import create_app
+
+
+def _pdf_bytes():
+    writer = PdfWriter()
+    writer.add_blank_page(width=10, height=10)
+    buf = BytesIO()
+    writer.write(buf)
+    buf.seek(0)
+    return buf.getvalue()
+
+
+def test_viewer_route_returns_html(tmp_path):
+    app = create_app()
+    app.config['UPLOAD_FOLDER'] = tmp_path
+    filename = 'test.pdf'
+    with open(tmp_path / filename, 'wb') as f:
+        f.write(_pdf_bytes())
+
+    client = app.test_client()
+    resp = client.get(f'/viewer/{filename}')
+    assert resp.status_code == 200
+    assert b'Visualizador de PDF' in resp.data
+
+
+def test_viewer_raw_serves_file(tmp_path):
+    app = create_app()
+    app.config['UPLOAD_FOLDER'] = tmp_path
+    filename = 'raw.pdf'
+    pdf_path = tmp_path / filename
+    with open(pdf_path, 'wb') as f:
+        f.write(_pdf_bytes())
+
+    client = app.test_client()
+    resp = client.get(f'/viewer/raw/{filename}')
+    assert resp.status_code == 200
+    assert resp.mimetype == 'application/pdf'
+
+
+def test_viewer_missing_returns_404(tmp_path):
+    app = create_app()
+    app.config['UPLOAD_FOLDER'] = tmp_path
+    client = app.test_client()
+    resp = client.get('/viewer/no.pdf')
+    assert resp.status_code == 404
+


### PR DESCRIPTION
## Summary
- implement `viewer` blueprint and template
- register new blueprint in the app factory
- fix wrong paths to `script.js` and `fileDropzone.js`
- complete PDF rendering logic in `script.js`
- add unit tests for the new viewer route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874e749f9088321bade015e18826520