### PR TITLE
Add CSP nonce support

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -71,6 +71,7 @@ def create_app():
     Talisman(
         app,
         content_security_policy=csp,
+        content_security_policy_nonce_in=['script'],
         force_https=force_https,
         strict_transport_security=True,
         strict_transport_security_max_age=31536000,

--- a/app/templates/compress.html
+++ b/app/templates/compress.html
@@ -44,9 +44,9 @@
         <a href="/split"><button>Dividir PDF</button></a>
     </div>
 
-    <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.9.179/build/pdf.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.9.179/build/pdf.worker.min.js"></script>
-    <script src="/static/fileDropzone.js" defer></script>
-    <script src="/static/script.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.9.179/build/pdf.min.js" nonce="{{ csp_nonce() }}"></script>
+    <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.9.179/build/pdf.worker.min.js" nonce="{{ csp_nonce() }}"></script>
+    <script src="/static/fileDropzone.js" defer nonce="{{ csp_nonce() }}"></script>
+    <script src="/static/script.js" defer nonce="{{ csp_nonce() }}"></script>
 </body>
 </html>

--- a/app/templates/converter.html
+++ b/app/templates/converter.html
@@ -41,9 +41,9 @@
         <a href="/compress"><button>Comprimir PDF</button></a>
     </div>
 
-    <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.9.179/build/pdf.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.9.179/build/pdf.worker.min.js"></script>
-    <script src="/static/fileDropzone.js" defer></script>
-    <script src="/static/script.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.9.179/build/pdf.min.js" nonce="{{ csp_nonce() }}"></script>
+    <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.9.179/build/pdf.worker.min.js" nonce="{{ csp_nonce() }}"></script>
+    <script src="/static/fileDropzone.js" defer nonce="{{ csp_nonce() }}"></script>
+    <script src="/static/script.js" defer nonce="{{ csp_nonce() }}"></script>
 </body>
 </html>

--- a/app/templates/merge.html
+++ b/app/templates/merge.html
@@ -42,9 +42,9 @@
         <a href="/compress"><button>Comprimir PDF</button></a>
     </div>
 
-    <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.9.179/build/pdf.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.9.179/build/pdf.worker.min.js"></script>
-    <script src="/static/fileDropzone.js" defer></script>
-    <script src="/static/script.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.9.179/build/pdf.min.js" nonce="{{ csp_nonce() }}"></script>
+    <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.9.179/build/pdf.worker.min.js" nonce="{{ csp_nonce() }}"></script>
+    <script src="/static/fileDropzone.js" defer nonce="{{ csp_nonce() }}"></script>
+    <script src="/static/script.js" defer nonce="{{ csp_nonce() }}"></script>
 </body>
 </html>

--- a/app/templates/split.html
+++ b/app/templates/split.html
@@ -41,9 +41,9 @@
         <a href="/compress"><button>Comprimir PDF</button></a>
     </div>
 
-    <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.9.179/build/pdf.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.9.179/build/pdf.worker.min.js"></script>
-    <script src="/static/fileDropzone.js" defer></script>
-    <script src="/static/script.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.9.179/build/pdf.min.js" nonce="{{ csp_nonce() }}"></script>
+    <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.9.179/build/pdf.worker.min.js" nonce="{{ csp_nonce() }}"></script>
+    <script src="/static/fileDropzone.js" defer nonce="{{ csp_nonce() }}"></script>
+    <script src="/static/script.js" defer nonce="{{ csp_nonce() }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- extend Flask-Talisman config with per-request nonce for script tags
- add the nonce attribute to all scripts in HTML templates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874f8718db08321a8097534e84a46ee