### PR TITLE
Fix CSP violations by removing inline JS

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -558,3 +558,7 @@ footer {
 #preview-close:hover {
   background: rgba(255,255,255,1);
 }
+
+/* Viewer specific styles */
+#controls { text-align: center; margin-bottom: 10px; }
+canvas#pdf-render { border: 1px solid #ddd; display: block; margin: 0 auto; }

--- a/app/static/viewer.js
+++ b/app/static/viewer.js
@@ -1,0 +1,52 @@
+const url = document.getElementById('pdf-render').dataset.url;
+
+let pdfDoc = null,
+    pageNum = 1,
+    isRendering = false,
+    pendingPage = null;
+
+const scale = 1.5,
+      canvas = document.getElementById('pdf-render'),
+      ctx = canvas.getContext('2d');
+
+function renderPage(num) {
+  isRendering = true;
+  pdfDoc.getPage(num).then(page => {
+    const viewport = page.getViewport({ scale });
+    canvas.height = viewport.height;
+    canvas.width  = viewport.width;
+    return page.render({ canvasContext: ctx, viewport }).promise;
+  }).then(() => {
+    isRendering = false;
+    if (pendingPage !== null) {
+      renderPage(pendingPage);
+      pendingPage = null;
+    }
+  });
+  document.getElementById('page_num').textContent = num;
+}
+
+function queueRender(num) {
+  isRendering ? pendingPage = num : renderPage(num);
+}
+
+document.getElementById('prev').addEventListener('click', () => {
+  if (pageNum <= 1) return;
+  pageNum--;
+  queueRender(pageNum);
+});
+
+document.getElementById('next').addEventListener('click', () => {
+  if (pageNum >= pdfDoc.numPages) return;
+  pageNum++;
+  queueRender(pageNum);
+});
+
+pdfjsLib.getDocument(url).promise
+  .then(doc => {
+    pdfDoc = doc;
+    document.getElementById('page_count').textContent = pdfDoc.numPages;
+    renderPage(pageNum);
+  })
+  .catch(err => console.error('Erro ao carregar PDF:', err));
+

--- a/app/templates/_preview_modal.html
+++ b/app/templates/_preview_modal.html
@@ -23,18 +23,7 @@
   </div>
 </div>
 
-<!-- 1) Carrega a lib PDF.js localmente -->
 <script src="{{ url_for('static', filename='pdfjs/pdf.min.js') }}"></script>
-
-<!-- 2) Configura o worker da mesma versão -->
-<script>
-  pdfjsLib.GlobalWorkerOptions.workerSrc = 
-    "{{ url_for('static', filename='pdfjs/pdf.worker.min.js') }}";
-</script>
-
-<!-- 3) Scripts auxiliares -->
 <script src="{{ url_for('static', filename='js/pdf-config.js') }}"></script>
 <script src="{{ url_for('static', filename='fileDropzone.js') }}"></script>
-
-<!-- 4) Seu script principal de preview -->
 <script src="{{ url_for('static', filename='script.js') }}"></script>

--- a/app/templates/viewer.html
+++ b/app/templates/viewer.html
@@ -3,11 +3,12 @@
 <head>
   <meta charset="UTF-8">
   <title>Visualizador de PDF</title>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.4.456/pdf.min.js"></script>
-  <style>
-    canvas { border: 1px solid #ddd; display: block; margin: 0 auto; }
-    #controls { text-align: center; margin-bottom: 10px; }
-  </style>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+  <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
+  <script src="{{ url_for('static', filename='pdfjs/pdf.min.js') }}"></script>
 </head>
 <body>
   <div id="controls">
@@ -15,60 +16,9 @@
     <span>Página <span id="page_num"></span> de <span id="page_count"></span></span>
     <button id="next">Próxima ›</button>
   </div>
-  <canvas id="pdf-render"></canvas>
+  <canvas id="pdf-render" data-url="{{ url_for('viewer.get_pdf', filename=filename) }}"></canvas>
 
-  <script>
-    const url = "{{ url_for('viewer.get_pdf', filename=filename) }}";
-
-    let pdfDoc = null,
-        pageNum = 1,
-        isRendering = false,
-        pendingPage = null;
-
-    const scale = 1.5,
-          canvas = document.getElementById('pdf-render'),
-          ctx = canvas.getContext('2d');
-
-    function renderPage(num) {
-      isRendering = true;
-      pdfDoc.getPage(num).then(page => {
-        const viewport = page.getViewport({ scale });
-        canvas.height = viewport.height;
-        canvas.width  = viewport.width;
-        return page.render({ canvasContext: ctx, viewport }).promise;
-      }).then(() => {
-        isRendering = false;
-        if (pendingPage !== null) {
-          renderPage(pendingPage);
-          pendingPage = null;
-        }
-      });
-      document.getElementById('page_num').textContent = num;
-    }
-
-    function queueRender(num) {
-      isRendering ? pendingPage = num : renderPage(num);
-    }
-
-    pdfjsLib.getDocument(url).promise
-      .then(doc => {
-        pdfDoc = doc;
-        document.getElementById('page_count').textContent = pdfDoc.numPages;
-        renderPage(pageNum);
-      })
-      .catch(err => console.error('Erro ao carregar PDF:', err));
-
-    document.getElementById('prev').addEventListener('click', () => {
-      if (pageNum <= 1) return;
-      pageNum--;
-      queueRender(pageNum);
-    });
-    document.getElementById('next').addEventListener('click', () => {
-      if (pageNum >= pdfDoc.numPages) return;
-      pageNum++;
-      queueRender(pageNum);
-    });
-  </script>
+  <script src="{{ url_for('static', filename='viewer.js') }}" defer></script>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- remove inline scripts to comply with Flask‑Talisman CSP
- host viewer page JavaScript in a new `viewer.js`
- include site CSS on viewer page and add viewer specific styles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874fbb604108321b135ab0494040660