### PR TITLE
Fix preview modal scripts and JS errors

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -144,17 +144,6 @@ function closePreview() {
   const imgContainer = document.getElementById('img-preview-container');
   if (imgContainer) imgContainer.classList.add('hidden');
 }
-  if (imgPreview) imgPreview.src = '';
-
-  modal.classList.remove('hidden');
-
-  if (file.type === 'application/pdf') {
-    previewPdfUrl = URL.createObjectURL(file);
-    renderPDF(previewPdfUrl);
-  } else if (file.type.startsWith('image/')) {
-    const url = URL.createObjectURL(file);
-    renderImage(url);
-  }
 
 
 function fecharPreview() {

--- a/app/templates/_preview_modal.html
+++ b/app/templates/_preview_modal.html
@@ -22,8 +22,3 @@
     </div>
   </div>
 </div>
-
-<script src="{{ url_for('static', filename='pdfjs/pdf.min.js') }}"></script>
-<script src="{{ url_for('static', filename='js/pdf-config.js') }}"></script>
-<script src="{{ url_for('static', filename='fileDropzone.js') }}"></script>
-<script src="{{ url_for('static', filename='script.js') }}"></script>


### PR DESCRIPTION
## Summary
- avoid loading scripts twice in preview modal
- clean leftover code from `script.js`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874fe92971c8321a894cfe2c996fe76