### PR TITLE
Unify PDF preview across pages

### DIFF
--- a/app/static/fileDropzone.js
+++ b/app/static/fileDropzone.js
@@ -1,109 +1,107 @@
-(function(){
-  window.createFileDropzone = function(options){
-    const {
-      dropzone,
-      input,
-      list,
-      extensions = [],
-      multiple = true,
-      onChange = function(){}
-    } = options;
-    let files = [];
+export function createFileDropzone(options) {
+  const {
+    dropzone,
+    input,
+    list,
+    extensions = [],
+    multiple = true,
+    onChange = () => {}
+  } = options;
 
-    function moverArquivo(index, offset){
-      const novoIndex = index + offset;
-      if(novoIndex < 0 || novoIndex >= files.length) return;
-      const [item] = files.splice(index, 1);
-      files.splice(novoIndex, 0, item);
-      updateList();
-      onChange(files);
+  let files = [];
+
+  function moverArquivo(index, offset) {
+    const novoIndex = index + offset;
+    if (novoIndex < 0 || novoIndex >= files.length) return;
+    const [item] = files.splice(index, 1);
+    files.splice(novoIndex, 0, item);
+    updateList();
+    onChange(files);
+  }
+
+  function updateList() {
+    if (!list) return;
+    list.innerHTML = '';
+    files.forEach((f, i) => {
+      const li = document.createElement('li');
+
+      const span = document.createElement('span');
+      span.textContent = f.name;
+      li.appendChild(span);
+
+      const actions = document.createElement('div');
+      actions.className = 'actions';
+
+      const up = document.createElement('button');
+      up.className = 'icon-btn';
+      up.textContent = '↑';
+      up.addEventListener('click', () => moverArquivo(i, -1));
+
+      const down = document.createElement('button');
+      down.className = 'icon-btn';
+      down.textContent = '↓';
+      down.addEventListener('click', () => moverArquivo(i, 1));
+
+      const del = document.createElement('button');
+      del.className = 'icon-btn';
+      del.textContent = '🗑';
+      del.addEventListener('click', () => removerArquivo(i));
+
+      actions.appendChild(up);
+      actions.appendChild(down);
+      actions.appendChild(del);
+
+      li.appendChild(actions);
+      list.appendChild(li);
+    });
+  }
+
+  function removerArquivo(index) {
+    files.splice(index, 1);
+    updateList();
+    onChange(files);
+  }
+
+  function validExtension(file) {
+    if (extensions.length === 0) return true;
+    const ext = '.' + file.name.split('.').pop().toLowerCase();
+    return extensions.includes(ext);
+  }
+
+  function addFiles(newFiles) {
+    const validFiles = Array.from(newFiles).filter(validExtension);
+    if (multiple) {
+      files = files.concat(validFiles);
+    } else if (validFiles.length) {
+      files = [validFiles[0]];
     }
+    updateList();
+    onChange(files);
+  }
 
-    function updateList(){
-      if(!list) return;
-      list.innerHTML = '';
-      files.forEach((f, i) => {
-        const li = document.createElement('li');
+  if (input) {
+    input.addEventListener('change', e => {
+      addFiles(e.target.files);
+      input.value = '';
+    });
+  }
 
-        const span = document.createElement('span');
-        span.textContent = f.name;
-        li.appendChild(span);
+  if (dropzone) {
+    dropzone.addEventListener('click', () => { if (input) input.click(); });
+    dropzone.addEventListener('dragover', e => {
+      e.preventDefault();
+      dropzone.classList.add('dragover');
+    });
+    dropzone.addEventListener('dragleave', () => dropzone.classList.remove('dragover'));
+    dropzone.addEventListener('drop', e => {
+      e.preventDefault();
+      dropzone.classList.remove('dragover');
+      addFiles(e.dataTransfer.files);
+    });
+  }
 
-        const actions = document.createElement('div');
-        actions.className = 'actions';
-
-        const up = document.createElement('button');
-        up.className = 'icon-btn';
-        up.textContent = '↑';
-        up.addEventListener('click', () => moverArquivo(i, -1));
-
-        const down = document.createElement('button');
-        down.className = 'icon-btn';
-        down.textContent = '↓';
-        down.addEventListener('click', () => moverArquivo(i, 1));
-
-        const del = document.createElement('button');
-        del.className = 'icon-btn';
-        del.textContent = '🗑';
-        del.addEventListener('click', () => removerArquivo(i));
-
-        actions.appendChild(up);
-        actions.appendChild(down);
-        actions.appendChild(del);
-
-        li.appendChild(actions);
-        list.appendChild(li);
-      });
-    }
-
-    window.removerArquivo = function(index){
-      files.splice(index, 1);
-      updateList();
-      onChange(files);
-    };
-
-
-    function validExtension(file){
-      if(extensions.length === 0) return true;
-      const ext = '.' + file.name.split('.').pop().toLowerCase();
-      return extensions.includes(ext);
-    }
-
-    function addFiles(newFiles){
-      const validFiles = Array.from(newFiles).filter(validExtension);
-      if(multiple){
-        files = files.concat(validFiles);
-      } else if(validFiles.length){
-        files = [validFiles[0]];
-      }
-      updateList();
-      onChange(files);
-    }
-
-    if(input){
-      input.addEventListener('change', e => {
-        addFiles(e.target.files);
-        input.value = '';
-      });
-    }
-
-    if(dropzone){
-      dropzone.addEventListener('click', () => { if(input) input.click(); });
-      dropzone.addEventListener('dragover', e => {
-        e.preventDefault();
-        dropzone.classList.add('dragover');
-      });
-      dropzone.addEventListener('dragleave', () => dropzone.classList.remove('dragover'));
-      dropzone.addEventListener('drop', e => {
-        e.preventDefault();
-        dropzone.classList.remove('dragover');
-        addFiles(e.dataTransfer.files);
-      });
-    }
-
-    return {
-      getFiles: () => files.slice(),
-      clear: () => { files = []; updateList(); onChange(files); }
-    };
+  return {
+    getFiles: () => files.slice(),
+    clear: () => { files = []; updateList(); onChange(files); }
   };
-})();
+}

--- a/app/static/js/preview.js
+++ b/app/static/js/preview.js
@@ -1,0 +1,66 @@
+const PREVIEW_BATCH_SIZE = 5;
+
+export async function previewPDF(file, containerEl, spinnerEl, actionBtnEl) {
+  const container = document.querySelector(containerEl);
+  const spinner = document.querySelector(spinnerEl);
+  const btn = document.querySelector(actionBtnEl);
+
+  if (!container || !spinner || !btn) return;
+  container.innerHTML = '';
+  spinner.style.display = 'flex';
+  btn.disabled = true;
+
+  try {
+    const arrayBuffer = await file.arrayBuffer();
+    const pdf = await pdfjsLib.getDocument(new Uint8Array(arrayBuffer)).promise;
+
+    let nextPage = 1;
+    for (let i = 1; i <= pdf.numPages; i++) {
+      const wrapper = document.createElement('div');
+      wrapper.classList.add('page-wrapper');
+      wrapper.setAttribute('aria-label', `Página ${i} de ${pdf.numPages}`);
+      wrapper.innerHTML = `
+        <div class="page-badge">Pg ${i}</div>
+        <canvas data-page="${i}"></canvas>
+        <span class="sr-only">Página ${i} de ${pdf.numPages}</span>
+      `;
+      container.appendChild(wrapper);
+    }
+
+    async function loadBatch() {
+      const end = Math.min(pdf.numPages, nextPage + PREVIEW_BATCH_SIZE - 1);
+      const renders = [];
+      for (let p = nextPage; p <= end; p++) {
+        renders.push(renderPage(pdf, p));
+      }
+      await Promise.all(renders);
+      nextPage = end + 1;
+    }
+
+    while (nextPage <= pdf.numPages) {
+      await loadBatch();
+    }
+
+    btn.disabled = false;
+  } catch (err) {
+    console.error('Preview falhou:', err);
+  } finally {
+    spinner.style.display = 'none';
+  }
+}
+
+async function renderPage(pdf, pageNumber) {
+  const page = await pdf.getPage(pageNumber);
+  const viewport = page.getViewport({ scale: 1.0 });
+  const canvas = document.querySelector(`canvas[data-page="${pageNumber}"]`);
+  canvas.width = viewport.width;
+  canvas.height = viewport.height;
+  await page.render({ canvasContext: canvas.getContext('2d'), viewport }).promise;
+}
+
+export function clearPreview(containerEl, actionBtnEl) {
+  const container = document.querySelector(containerEl);
+  const btn = document.querySelector(actionBtnEl);
+  if (container) container.innerHTML = '';
+  if (btn) btn.disabled = true;
+}

--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -1,0 +1,54 @@
+import { previewPDF, clearPreview } from './preview.js';
+import { createFileDropzone } from '../fileDropzone.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const configs = [
+    {
+      dropzoneEl: '#dropzone-merge',
+      inputEl: '#input-merge',
+      listEl: '#list-merge',
+      previewEl: '#preview-merge',
+      spinnerEl: '#spinner-merge',
+      actionBtnEl: '#btn-merge',
+      extensions: ['.pdf'],
+      multiple: true,
+    },
+    {
+      dropzoneEl: '#dropzone-split',
+      inputEl: '#input-split',
+      listEl: '#list-split',
+      previewEl: '#preview-split',
+      spinnerEl: '#spinner-split',
+      actionBtnEl: '#btn-split',
+      extensions: ['.pdf'],
+      multiple: false,
+    },
+    {
+      dropzoneEl: '#dropzone-compress',
+      inputEl: '#input-compress',
+      listEl: '#list-compress',
+      previewEl: '#preview-compress',
+      spinnerEl: '#spinner-compress',
+      actionBtnEl: '#btn-compress',
+      extensions: ['.pdf'],
+      multiple: true,
+    }
+  ];
+
+  configs.forEach(cfg => {
+    const dz = createFileDropzone({
+      dropzone: document.querySelector(cfg.dropzoneEl),
+      input: document.querySelector(cfg.inputEl),
+      list: document.querySelector(cfg.listEl),
+      extensions: cfg.extensions,
+      multiple: cfg.multiple,
+      onChange: files => {
+        if (files.length) {
+          previewPDF(files[0], cfg.previewEl, cfg.spinnerEl, cfg.actionBtnEl);
+        } else {
+          clearPreview(cfg.previewEl, cfg.actionBtnEl);
+        }
+      }
+    });
+  });
+});

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -624,3 +624,38 @@ canvas#pdf-render { border: 1px solid #ddd; display: block; margin: 0 auto; }
     grid-template-columns: repeat(auto-fill, minmax(80px,1fr));
   }
 }
+
+.preview-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px,1fr));
+  gap: 12px;
+  position: relative;
+}
+.page-wrapper { position: relative; }
+.page-badge {
+  position: absolute;
+  top: 4px; left: 4px;
+  background: rgba(0,153,93,0.8);
+  color: #fff;
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: .75em;
+}
+.overlay-spinner {
+  position: absolute;
+  top:0; left:0; right:0; bottom:0;
+  background: rgba(255,255,255,0.8);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+}
+.overlay-spinner .loader {
+  width: 36px;
+  height: 36px;
+  border: 4px solid #00995d;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+@keyframes spin { to { transform: rotate(360deg); } }

--- a/app/templates/compress.html
+++ b/app/templates/compress.html
@@ -9,6 +9,10 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
     <meta name="csrf-token" content="{{ csrf_token() }}">
+    <script src="{{ url_for('static', filename='pdfjs/pdf.min.js') }}"></script>
+    <script>pdfjsLib.GlobalWorkerOptions.workerSrc = '{{ url_for("static", filename="pdfjs/pdf.worker.min.js") }}';</script>
+    <script type="module" src="{{ url_for('static', filename='js/preview.js') }}"></script>
+    <script type="module" src="{{ url_for('static', filename='js/script.js') }}"></script>
 </head>
 <body>
     <header class="header-flex">
@@ -22,13 +26,18 @@
         <section class="card">
             <form action="{{ url_for('compress.compress') }}" method="post" enctype="multipart/form-data">
                 <label>Escolha um arquivo PDF:</label>
-                <div id="dropzone" class="dropzone">
-                    <input type="file" name="file" id="file-input" accept=".pdf">
+                <div id="dropzone-compress" class="dropzone">
+                    <input type="file" name="file" id="input-compress" accept=".pdf">
                     Arraste o arquivo aqui ou clique para selecionar
                 </div>
-                <ul id="lista-arquivos"></ul>
-                <button type="submit">Comprimir PDF</button>
-                <button id="preview-btn" type="button">Visualizar</button>
+                <div class="preview-area">
+                  <div id="spinner-compress" class="overlay-spinner" aria-hidden="true">
+                    <div class="loader"></div>
+                  </div>
+                  <div id="preview-compress" class="preview-grid"></div>
+                </div>
+                <ul id="list-compress"></ul>
+                <button id="btn-compress" type="submit" disabled>Comprimir PDF</button>
             </form>
         </section>
 
@@ -47,10 +56,4 @@
     </div>
 
     {% include '_preview_modal.html' %}
-
-    <!-- Scripts: PDF.js, configuração do worker, dropzone e lógica principal -->
-    <script src="{{ url_for('static', filename='pdfjs/pdf.min.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/pdf-config.js') }}"></script>
-    <script src="{{ url_for('static', filename='fileDropzone.js') }}" defer></script>
-    <script src="{{ url_for('static', filename='script.js') }}" defer></script>
 </body></html>

--- a/app/templates/converter.html
+++ b/app/templates/converter.html
@@ -9,6 +9,10 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
     <meta name="csrf-token" content="{{ csrf_token() }}">
+    <script src="{{ url_for('static', filename='pdfjs/pdf.min.js') }}"></script>
+    <script>pdfjsLib.GlobalWorkerOptions.workerSrc = '{{ url_for("static", filename="pdfjs/pdf.worker.min.js") }}';</script>
+    <script type="module" src="{{ url_for('static', filename='js/preview.js') }}"></script>
+    <script type="module" src="{{ url_for('static', filename='js/script.js') }}"></script>
 </head>
 <body>
     <header class="header-flex">
@@ -20,13 +24,18 @@
 
     <main>
         <section class="card">
-            <div id="dropzone" class="dropzone">
-                <input type="file" id="file-input" accept=".doc,.docx,.odt,.ods,.odp,.jpg,.jpeg,.png,.csv,.xls,.xlsx" multiple>
+            <div id="dropzone-convert" class="dropzone">
+                <input type="file" id="input-convert" accept=".doc,.docx,.odt,.ods,.odp,.jpg,.jpeg,.png,.csv,.xls,.xlsx" multiple>
                 Arraste os arquivos aqui ou clique para selecionar
             </div>
-            <ul id="lista-arquivos"></ul>
-            <button id="converter-btn">Converter Todos</button>
-            <button id="preview-btn" type="button">Visualizar</button>
+            <div class="preview-area">
+              <div id="spinner-convert" class="overlay-spinner" aria-hidden="true">
+                <div class="loader"></div>
+              </div>
+              <div id="preview-convert" class="preview-grid"></div>
+            </div>
+            <ul id="list-convert"></ul>
+            <button id="btn-convert" disabled>Converter Todos</button>
         </section>
 
         <div id="mensagem-feedback" class="hidden"></div>
@@ -44,10 +53,4 @@
     </div>
 
     {% include '_preview_modal.html' %}
-
-    <!-- Scripts: PDF.js, configuração do worker, dropzone e lógica principal -->
-    <script src="{{ url_for('static', filename='pdfjs/pdf.min.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/pdf-config.js') }}"></script>
-    <script src="{{ url_for('static', filename='fileDropzone.js') }}" defer></script>
-    <script src="{{ url_for('static', filename='script.js') }}" defer></script>
 </body></html>

--- a/app/templates/merge.html
+++ b/app/templates/merge.html
@@ -9,6 +9,10 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
     <meta name="csrf-token" content="{{ csrf_token() }}">
+    <script src="{{ url_for('static', filename='pdfjs/pdf.min.js') }}"></script>
+    <script>pdfjsLib.GlobalWorkerOptions.workerSrc = '{{ url_for("static", filename="pdfjs/pdf.worker.min.js") }}';</script>
+    <script type="module" src="{{ url_for('static', filename='js/preview.js') }}"></script>
+    <script type="module" src="{{ url_for('static', filename='js/script.js') }}"></script>
 </head>
 <body>
     <header class="header-flex">
@@ -20,16 +24,19 @@
 
     <main>
         <section class="card">
-            <div id="dropzone" class="dropzone">
-                <input type="file" id="file-input" accept=".pdf" multiple>
+            <div id="dropzone-merge" class="dropzone">
+                <input type="file" id="input-merge" accept=".pdf" multiple>
                 Arraste os arquivos aqui ou clique para selecionar
             </div>
-            <div id="preview-container" class="preview-grid"></div>
-            <div id="preview-loading" class="hidden">Carregando pré-visualização…</div>
+            <div class="preview-area">
+              <div id="spinner-merge" class="overlay-spinner" aria-hidden="true">
+                <div class="loader"></div>
+              </div>
+              <div id="preview-merge" class="preview-grid"></div>
+            </div>
             <p>Use os botões ↑ e ↓ ao lado de cada arquivo para definir a ordem.</p>
-            <ul id="lista-arquivos"></ul>
-            <button id="merge-btn">Juntar PDFs</button>
-            <button id="preview-btn" type="button">Visualizar</button>
+            <ul id="list-merge"></ul>
+            <button id="btn-merge" disabled>Juntar PDFs</button>
         </section>
 
         <div id="mensagem-feedback" class="hidden"></div>
@@ -47,11 +54,4 @@
     </div>
 
     {% include '_preview_modal.html' %}
-
-    <!-- Scripts: PDF.js, configuração do worker, dropzone e lógica principal -->
-    <script src="{{ url_for('static', filename='pdfjs/pdf.min.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/pdf-config.js') }}"></script>
-    <script src="{{ url_for('static', filename='fileDropzone.js') }}" defer></script>
-    <script src="{{ url_for('static', filename='preview.js') }}" defer></script>
-    <script src="{{ url_for('static', filename='script.js') }}" defer></script>
   </body></html>

--- a/app/templates/split.html
+++ b/app/templates/split.html
@@ -9,6 +9,10 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
     <meta name="csrf-token" content="{{ csrf_token() }}">
+    <script src="{{ url_for('static', filename='pdfjs/pdf.min.js') }}"></script>
+    <script>pdfjsLib.GlobalWorkerOptions.workerSrc = '{{ url_for("static", filename="pdfjs/pdf.worker.min.js") }}';</script>
+    <script type="module" src="{{ url_for('static', filename='js/preview.js') }}"></script>
+    <script type="module" src="{{ url_for('static', filename='js/script.js') }}"></script>
 </head>
 <body>
     <header class="header-flex">
@@ -24,14 +28,19 @@
 
     <main>
         <section class="card">
-            <div id="dropzone" class="dropzone">
-                <input type="file" id="file-input" accept=".pdf" multiple>
+            <div id="dropzone-split" class="dropzone">
+                <input type="file" id="input-split" accept=".pdf" multiple>
                 Arraste os arquivos aqui ou clique para selecionar
             </div>
+            <div class="preview-area">
+              <div id="spinner-split" class="overlay-spinner" aria-hidden="true">
+                <div class="loader"></div>
+              </div>
+              <div id="preview-split" class="preview-grid"></div>
+            </div>
             <p>Use os botões ↑ e ↓ ao lado de cada arquivo para definir a ordem.</p>
-            <ul id="lista-arquivos"></ul>
-            <button id="merge-btn">Juntar PDFs</button>
-            <button id="preview-btn" type="button">Visualizar</button>
+            <ul id="list-split"></ul>
+            <button id="btn-split" disabled>Juntar PDFs</button>
         </section>
 
         <div id="mensagem-feedback" class="hidden"></div>
@@ -49,10 +58,4 @@
     </div>
 
     {% include '_preview_modal.html' %}
-
-    <!-- Scripts: PDF.js, configuração do worker, dropzone e lógica principal -->
-    <script src="{{ url_for('static', filename='pdfjs/pdf.min.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/pdf-config.js') }}" defer></script>
-    <script src="{{ url_for('static', filename='fileDropzone.js') }}" defer></script>
-    <script src="{{ url_for('static', filename='script.js') }}" defer></script>
 </body></html>


### PR DESCRIPTION
## Summary
- introduce `static/js/preview.js` with reusable preview logic
- convert `fileDropzone.js` to an ES module
- centralize dropzone behaviour in new `static/js/script.js`
- add overlay spinner and preview grid styles
- update templates to plug new module-based preview

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687508c5c9d48321aa07cfd1d5ac97a1