### PR TITLE
Enable page selection in PDF previews

### DIFF
--- a/app/static/js/preview.js
+++ b/app/static/js/preview.js
@@ -1,7 +1,14 @@
 const PREVIEW_BATCH_SIZE = 5;
 const PREVIEW_TIMEOUT = 30000;
-// largura do thumbnail em pixels
-const THUMB_WIDTH = 120;
+// largura em CSS-pixels da miniatura final
+const THUMB_WIDTH = 100;
+
+const selectedPages = new Set();
+
+export function getSelectedPages() {
+  // retorna número das páginas que o usuário deixou “marcadas”
+  return Array.from(selectedPages).sort((a, b) => a - b);
+}
 
 export async function previewPDF(file, containerEl, spinnerEl, actionBtnEl) {
   const container = document.querySelector(containerEl);
@@ -27,9 +34,12 @@ export async function previewPDF(file, containerEl, spinnerEl, actionBtnEl) {
 
     container.innerHTML = '';
 
+    selectedPages.clear();
+
     let nextPage = 1;
     for (let i = 1; i <= pdf.numPages; i++) {
       const wrapper = document.createElement('div');
+      wrapper.dataset.page = i;
       wrapper.classList.add('page-wrapper');
       wrapper.setAttribute('aria-label', `Página ${i} de ${pdf.numPages}`);
       wrapper.innerHTML = `
@@ -37,6 +47,16 @@ export async function previewPDF(file, containerEl, spinnerEl, actionBtnEl) {
         <canvas data-page="${i}"></canvas>
         <span class="sr-only">Página ${i} de ${pdf.numPages}</span>
       `;
+      wrapper.addEventListener('click', () => {
+        const pg = Number(wrapper.dataset.page);
+        if (selectedPages.has(pg)) {
+          selectedPages.delete(pg);
+          wrapper.classList.remove('selected');
+        } else {
+          selectedPages.add(pg);
+          wrapper.classList.add('selected');
+        }
+      });
       container.appendChild(wrapper);
     }
 
@@ -87,6 +107,7 @@ async function renderPage(pdf, pageNumber) {
 export function clearPreview(containerEl, actionBtnEl) {
   const container = document.querySelector(containerEl);
   const btn = document.querySelector(actionBtnEl);
+  selectedPages.clear();
   if (container) container.innerHTML = '';
   if (btn) btn.disabled = true;
 }

--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -1,7 +1,14 @@
-import { previewPDF, clearPreview } from './preview.js';
+import { previewPDF, clearPreview, getSelectedPages } from './preview.js';
 import { createFileDropzone } from '../fileDropzone.js';
 
+function getCSRFToken() {
+  const meta = document.querySelector('meta[name="csrf-token"]');
+  return meta ? meta.getAttribute('content') : '';
+}
+
 document.addEventListener('DOMContentLoaded', () => {
+  let mergeDZ;
+
   document.querySelectorAll('.dropzone').forEach(dzEl => {
     const cfg = {
       dropzone: dzEl,
@@ -18,6 +25,34 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     };
 
-    createFileDropzone(cfg);
+    const instance = createFileDropzone(cfg);
+    if (dzEl.id === 'dropzone-merge') mergeDZ = instance;
   });
+
+  const mergeBtn = document.querySelector('#btn-merge');
+  if (mergeBtn) {
+    mergeBtn.addEventListener('click', () => {
+      const pages = getSelectedPages();
+      const form = new FormData();
+      const file = mergeDZ ? mergeDZ.getFiles()[0] : null;
+      if (!file) return;
+      form.append('file', file);
+      form.append('pages', JSON.stringify(pages));
+      fetch('/api/merge', {
+        method: 'POST',
+        body: form,
+        headers: { 'X-CSRFToken': getCSRFToken() }
+      })
+        .then(r => r.blob())
+        .then(blob => {
+          const url = URL.createObjectURL(blob);
+          const a = document.createElement('a');
+          a.href = url;
+          a.download = 'merged.pdf';
+          document.body.appendChild(a);
+          a.click();
+          a.remove();
+        });
+    });
+  }
 });

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -627,19 +627,30 @@ canvas#pdf-render { border: 1px solid #ddd; display: block; margin: 0 auto; }
 
 .preview-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(120px,1fr));
+  grid-template-columns: repeat(auto-fill, minmax(100px,1fr));
   gap: 12px;
   position: relative;
 }
-.page-wrapper { position: relative; }
+.page-wrapper {
+  position: relative;
+  cursor: pointer;
+  overflow: hidden;
+  border: 2px solid transparent;
+  border-radius: 4px;
+  transition: border-color .2s ease;
+}
+.page-wrapper.selected {
+  border-color: #00995d;
+}
 .page-badge {
   position: absolute;
   top: 4px; left: 4px;
-  background: rgba(0,153,93,0.8);
+  background: rgba(0,153,93,0.9);
   color: #fff;
   padding: 2px 6px;
   border-radius: 3px;
-  font-size: .75em;
+  font-size: .7em;
+  z-index: 2;
 }
 .overlay-spinner {
   position: absolute;


### PR DESCRIPTION
## Summary
- support choosing pages from a single PDF when merging
- show selectable page thumbnails with new styling
- post selected pages via fetch using CSRF token

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875100469f48321945828eed37404f9