### PR TITLE
Update UI to thumbnail grid

### DIFF
--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -17,24 +17,24 @@ function mostrarMensagem(msg, tipo = 'sucesso') {
 
 document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('.dropzone').forEach(dzEl => {
-    const inputSel   = dzEl.dataset.input;
-    const listSel    = dzEl.dataset.list;
+    const inputEl    = dzEl.querySelector('input[type="file"]');
     const previewSel = dzEl.dataset.preview;
     const spinnerSel = dzEl.dataset.spinner;
     const btnSel     = dzEl.dataset.action;
+    const exts       = dzEl.dataset.extensions ? dzEl.dataset.extensions.split(',') : ['.pdf'];
+    const allowMultiple = dzEl.dataset.multiple === 'true';
 
     const dz = createFileDropzone({
       dropzone: dzEl,
-      input: document.querySelector(inputSel),
-      list: document.querySelector(listSel),
-      extensions: dzEl.dataset.extensions ? dzEl.dataset.extensions.split(',') : ['.pdf'],
-      multiple: dzEl.dataset.multiple === 'true',
+      input:    inputEl,
+      extensions: exts,
+      multiple:   allowMultiple,
       onChange: files => {
         if (files.length) {
           previewPDF(files[0], previewSel, spinnerSel, btnSel);
         } else {
-          document.querySelector(previewSel).innerHTML = '';
           clearSelection();
+          document.querySelector(previewSel).innerHTML = '';
           document.querySelector(btnSel).disabled = true;
         }
       }

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -670,3 +670,5 @@ canvas#pdf-render { border: 1px solid #ddd; display: block; margin: 0 auto; }
   animation: spin 1s linear infinite;
 }
 @keyframes spin { to { transform: rotate(360deg); } }
+
+#lista-arquivos { display: none !important; }

--- a/app/templates/compress.html
+++ b/app/templates/compress.html
@@ -29,18 +29,15 @@
             <form action="{{ url_for('compress.compress') }}" method="post" enctype="multipart/form-data">
                 <label>Escolha um arquivo PDF:</label>
                 <div id="dropzone-{{ prefix }}" class="dropzone"
-                     data-input="#input-{{ prefix }}"
-                     data-list="#list-{{ prefix }}"
                      data-preview="#preview-{{ prefix }}"
                      data-spinner="#spinner-{{ prefix }}"
                      data-action="#btn-{{ prefix }}"
                      data-extensions=".pdf"
                      data-multiple="true">
+                    <input type="file" name="file" id="input-{{ prefix }}" accept=".pdf">
                     Arraste o arquivo aqui ou clique para selecionar
                 </div>
-                <input type="file" name="file" id="input-{{ prefix }}" accept=".pdf">
                 {{ macros.preview_area('spinner-' ~ prefix, 'preview-' ~ prefix) }}
-                <ul id="list-{{ prefix }}"></ul>
                 <button id="btn-{{ prefix }}" type="submit" disabled>Comprimir PDF</button>
             </form>
         </section>

--- a/app/templates/converter.html
+++ b/app/templates/converter.html
@@ -27,18 +27,15 @@
         {% set prefix = 'convert' %}
         <section class="card">
             <div id="dropzone-{{ prefix }}" class="dropzone"
-                 data-input="#input-{{ prefix }}"
-                 data-list="#list-{{ prefix }}"
                  data-preview="#preview-{{ prefix }}"
                  data-spinner="#spinner-{{ prefix }}"
                  data-action="#btn-{{ prefix }}"
                  data-extensions=".doc,.docx,.odt,.ods,.odp,.jpg,.jpeg,.png,.csv,.xls,.xlsx"
                  data-multiple="true">
+                <input type="file" id="input-{{ prefix }}" accept=".doc,.docx,.odt,.ods,.odp,.jpg,.jpeg,.png,.csv,.xls,.xlsx" multiple>
                 Arraste os arquivos aqui ou clique para selecionar
             </div>
-            <input type="file" id="input-{{ prefix }}" accept=".doc,.docx,.odt,.ods,.odp,.jpg,.jpeg,.png,.csv,.xls,.xlsx" multiple>
             {{ macros.preview_area('spinner-' ~ prefix, 'preview-' ~ prefix) }}
-            <ul id="list-{{ prefix }}"></ul>
             <button id="btn-{{ prefix }}" disabled>Converter Todos</button>
         </section>
 

--- a/app/templates/merge.html
+++ b/app/templates/merge.html
@@ -27,19 +27,15 @@
         {% set prefix = 'merge' %}
         <section class="card">
             <div id="dropzone-{{ prefix }}" class="dropzone"
-                 data-input="#input-{{ prefix }}"
-                 data-list="#list-{{ prefix }}"
                  data-preview="#preview-{{ prefix }}"
                  data-spinner="#spinner-{{ prefix }}"
                  data-action="#btn-{{ prefix }}"
                  data-extensions=".pdf"
                  data-multiple="true">
+                <input type="file" id="input-{{ prefix }}" accept=".pdf" multiple>
                 Arraste os arquivos aqui ou clique para selecionar
             </div>
-            <input type="file" id="input-{{ prefix }}" accept=".pdf" multiple>
             {{ macros.preview_area('spinner-' ~ prefix, 'preview-' ~ prefix) }}
-            <p>Use os botões ↑ e ↓ ao lado de cada arquivo para definir a ordem.</p>
-            <ul id="list-{{ prefix }}"></ul>
             <button id="btn-{{ prefix }}" disabled>Juntar PDFs</button>
         </section>
 

--- a/app/templates/split.html
+++ b/app/templates/split.html
@@ -31,19 +31,15 @@
         {% set prefix = 'split' %}
         <section class="card">
             <div id="dropzone-{{ prefix }}" class="dropzone"
-                 data-input="#input-{{ prefix }}"
-                 data-list="#list-{{ prefix }}"
                  data-preview="#preview-{{ prefix }}"
                  data-spinner="#spinner-{{ prefix }}"
                  data-action="#btn-{{ prefix }}"
                  data-extensions=".pdf"
                  data-multiple="false">
+                <input type="file" id="input-{{ prefix }}" accept=".pdf" multiple>
                 Arraste os arquivos aqui ou clique para selecionar
             </div>
-            <input type="file" id="input-{{ prefix }}" accept=".pdf" multiple>
             {{ macros.preview_area('spinner-' ~ prefix, 'preview-' ~ prefix) }}
-            <p>Use os botões ↑ e ↓ ao lado de cada arquivo para definir a ordem.</p>
-            <ul id="list-{{ prefix }}"></ul>
             <button id="btn-{{ prefix }}" disabled>Juntar PDFs</button>
         </section>
 


### PR DESCRIPTION
## Summary
- drop the old file list from all PDF tools
- keep file input inside dropzone containers
- adapt JS to work without the list element
- hide `#lista-arquivos` in CSS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68752baef0c88321aecbe9d434ac55bb