### PR TITLE
Enable preview for multiple PDFs

### DIFF
--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -30,13 +30,20 @@ document.addEventListener('DOMContentLoaded', () => {
       extensions: exts,
       multiple:   allowMultiple,
       onChange: files => {
-        if (files.length) {
-          previewPDF(files[0], previewSel, spinnerSel, btnSel);
-        } else {
-          clearSelection();
-          document.querySelector(previewSel).innerHTML = '';
-          document.querySelector(btnSel).disabled = true;
-        }
+        const root = document.querySelector(previewSel);
+        clearSelection();
+        root.innerHTML = '';
+        document.querySelector(btnSel).disabled = true;
+
+        if (!files.length) return;
+
+        files.forEach(file => {
+          const fileWrapper = document.createElement('div');
+          fileWrapper.classList.add('file-wrapper');
+          root.appendChild(fileWrapper);
+
+          previewPDF(file, fileWrapper, spinnerSel, btnSel);
+        });
       }
     });
 

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -631,6 +631,15 @@ canvas#pdf-render { border: 1px solid #ddd; display: block; margin: 0 auto; }
   gap: 12px;
   position: relative;
 }
+.file-wrapper {
+  margin-bottom: 24px;
+}
+
+.file-wrapper .preview-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(100px,1fr));
+  gap: 12px;
+}
 .page-wrapper {
   position: relative;
   cursor: pointer;


### PR DESCRIPTION
## Summary
- support rendering multiple PDFs by iterating all files
- allow `previewPDF` to accept DOM elements and update render logic
- add CSS wrapper for grouped previews

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68752e1c7e4c8321833ae09251090502