### PR TITLE
Improve PDF routes and compression settings

### DIFF
--- a/app/routes/compress.py
+++ b/app/routes/compress.py
@@ -17,9 +17,13 @@ def compress():
     file = request.files['file']
     if file.filename == '':
         return jsonify({'error': 'Nenhum arquivo selecionado.'}), 400
+    if not file.filename.lower().endswith('.pdf'):
+        return jsonify({'error': 'Envie apenas um arquivo PDF válido.'}), 400
+
+    level = request.form.get('level', 'ebook')
 
     try:
-        output_path = comprimir_pdf(file)
+        output_path = comprimir_pdf(file, level)
 
         @after_this_request
         def cleanup(response):

--- a/app/routes/converter.py
+++ b/app/routes/converter.py
@@ -4,6 +4,7 @@ from ..services.converter_service import (
     converter_doc_para_pdf,
     converter_planilha_para_pdf
 )
+from ..utils.config_utils import allowed_file
 from werkzeug.utils import secure_filename
 from .. import limiter
 
@@ -23,7 +24,7 @@ def convert():
 
     # Determina a extensão para escolher o serviço correto
     filename = secure_filename(file.filename)
-    if '.' not in filename:
+    if not allowed_file(filename):
         return jsonify({'error': 'Extensão de arquivo inválida.'}), 400
     ext = filename.rsplit('.', 1)[1].lower()
 

--- a/app/routes/merge.py
+++ b/app/routes/merge.py
@@ -17,6 +17,10 @@ def merge():
     if len(files) < 2:
         return jsonify({'error': 'Envie pelo menos dois arquivos PDF.'}), 400
 
+    for f in files:
+        if not f.filename.lower().endswith('.pdf'):
+            return jsonify({'error': 'Envie apenas arquivos PDF válidos.'}), 400
+
     try:
         output_path = juntar_pdfs(files)
 

--- a/app/routes/split.py
+++ b/app/routes/split.py
@@ -18,6 +18,8 @@ def split():
 
     if file.filename == '':
         return jsonify({'error': 'Nenhum arquivo selecionado.'}), 400
+    if not file.filename.lower().endswith('.pdf'):
+        return jsonify({'error': 'Envie apenas um arquivo PDF válido.'}), 400
 
     try:
         pdf_paths = dividir_pdf(file)

--- a/app/services/converter_service.py
+++ b/app/services/converter_service.py
@@ -43,13 +43,20 @@ def converter_doc_para_pdf(file):
             else:
                 libreoffice_cmd = 'libreoffice'
 
-        subprocess.run([
-            libreoffice_cmd,
-            '--headless',
-            '--convert-to', 'pdf',
-            input_path,
-            '--outdir', upload_folder
-        ], check=True, timeout=LIBREOFFICE_TIMEOUT)
+        try:
+            subprocess.run([
+                libreoffice_cmd,
+                '--headless',
+                '--convert-to', 'pdf',
+                input_path,
+                '--outdir', upload_folder
+            ], check=True, timeout=LIBREOFFICE_TIMEOUT)
+        except subprocess.TimeoutExpired:
+            os.remove(input_path)
+            raise Exception('Tempo limite excedido na conversão do documento.')
+        except subprocess.CalledProcessError as e:
+            os.remove(input_path)
+            raise Exception('Erro ao converter o documento.') from e
         os.rename(temp_output, unique_output)
 
     os.remove(input_path)
@@ -79,13 +86,20 @@ def converter_planilha_para_pdf(file):
             libreoffice_cmd = 'libreoffice'
 
     # Executa conversão para PDF
-    subprocess.run([
-        libreoffice_cmd,
-        '--headless',
-        '--convert-to', 'pdf',
-        input_path,
-        '--outdir', upload_folder
-    ], check=True, timeout=LIBREOFFICE_TIMEOUT)
+    try:
+        subprocess.run([
+            libreoffice_cmd,
+            '--headless',
+            '--convert-to', 'pdf',
+            input_path,
+            '--outdir', upload_folder
+        ], check=True, timeout=LIBREOFFICE_TIMEOUT)
+    except subprocess.TimeoutExpired:
+        os.remove(input_path)
+        raise Exception('Tempo limite excedido na conversão da planilha.')
+    except subprocess.CalledProcessError as e:
+        os.remove(input_path)
+        raise Exception('Erro ao converter a planilha.') from e
 
     temp_output = os.path.splitext(input_path)[0] + '.pdf'
     unique_output = os.path.join(upload_folder, f"{uuid.uuid4().hex}.pdf")

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -231,6 +231,10 @@ function enviarArquivoCompress(event) {
 
   const formData = new FormData();
   formData.append('file', input.files[0]);
+  const levelSelect = document.getElementById('level');
+  if (levelSelect) {
+    formData.append('level', levelSelect.value);
+  }
 
   const xhr = new XMLHttpRequest();
   xhr.open('POST', '/api/compress');

--- a/app/templates/compress.html
+++ b/app/templates/compress.html
@@ -27,6 +27,13 @@
                     Arraste o arquivo aqui ou clique para selecionar
                 </div>
                 <ul id="lista-arquivos"></ul>
+                <label for="level">Nível de compressão:</label>
+                <select name="level" id="level">
+                    <option value="screen">Baixa</option>
+                    <option value="ebook" selected>E-book</option>
+                    <option value="printer">Impressão</option>
+                    <option value="prepress">Prepress</option>
+                </select>
                 <button type="submit">Comprimir PDF</button>
             </form>
         </section>


### PR DESCRIPTION
## Summary
- add allowed extension checks in PDF routes
- allow Ghostscript compression level selection
- handle subprocess errors with better messages
- support compression level in frontend form and JS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687536140e3c83219481213231e3462a