### PR TITLE
Implement linting and new tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8
+        additional_dependencies: []

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203,W503

--- a/tests/e2e/test_merge_e2e.py
+++ b/tests/e2e/test_merge_e2e.py
@@ -1,0 +1,54 @@
+import os
+import sys
+import threading
+import time
+from werkzeug.serving import make_server
+from playwright.sync_api import sync_playwright
+from PyPDF2 import PdfWriter, PdfReader
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+from app import create_app  # noqa: E402
+
+
+def _make_pdf(path):
+    writer = PdfWriter()
+    writer.add_blank_page(width=10, height=10)
+    writer.add_blank_page(width=20, height=20)
+    with open(path, "wb") as f:
+        writer.write(f)
+
+
+def _start_server(tmpdir):
+    app = create_app()
+    app.config["UPLOAD_FOLDER"] = str(tmpdir)
+    app.config["WTF_CSRF_ENABLED"] = False
+    server = make_server("127.0.0.1", 5001, app)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    time.sleep(1)
+    return server, thread
+
+
+def test_merge_flow(tmp_path):
+    pdf_path = tmp_path / "test.pdf"
+    _make_pdf(pdf_path)
+    server, thread = _start_server(tmp_path)
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.goto("http://127.0.0.1:5001/merge")
+        page.set_input_files("input#input-merge", str(pdf_path))
+        page.wait_for_selector('canvas[data-page="1"]')
+        page.click('.page-wrapper[data-page="1"]')
+        with page.expect_download() as dl_info:
+            page.click("#btn-merge")
+        download = dl_info.value
+        out_file = tmp_path / "out.pdf"
+        download.save_as(out_file)
+        browser.close()
+
+    server.shutdown()
+    thread.join()
+    reader = PdfReader(str(out_file))
+    assert len(reader.pages) == 1

--- a/tests/test_pdf_extrair_split.py
+++ b/tests/test_pdf_extrair_split.py
@@ -1,0 +1,84 @@
+import os
+from io import BytesIO
+from werkzeug.datastructures import FileStorage
+from app import create_app
+from app.services import merge_service, split_service
+
+
+def _fake_pdf_data():
+    return BytesIO(b"pdf")
+
+
+class DummyPage:
+    pass
+
+
+class FakeReader:
+    def __init__(self, path):
+        self.pages = [DummyPage(), DummyPage(), DummyPage()]
+        self.path = path
+
+
+class FakeWriter:
+    def __init__(self):
+        self.added = []
+
+    def add_page(self, page):
+        self.added.append(page)
+
+    def write(self, f):
+        self.out_path = f.name
+        open(f.name, "wb").close()
+
+
+def test_extrair_paginas_pdf(monkeypatch, tmp_path):
+    app = create_app()
+    app.config["UPLOAD_FOLDER"] = tmp_path
+
+    reader = FakeReader
+    writer = FakeWriter()
+
+    monkeypatch.setattr(merge_service, "PdfReader", reader)
+    monkeypatch.setattr(merge_service, "PdfWriter", lambda: writer)
+
+    with app.app_context():
+        f = FileStorage(stream=_fake_pdf_data(), filename="a.pdf")
+        out = merge_service.extrair_paginas_pdf(f, [1, 3])
+
+    assert len(writer.added) == 2
+    assert os.path.exists(out)
+    assert writer.out_path == out
+
+
+class FakeSplitReader:
+    def __init__(self, path):
+        self.pages = [DummyPage(), DummyPage()]
+        self.path = path
+
+
+class FakeSplitWriter:
+    def __init__(self):
+        self.pages = []
+
+    def add_page(self, page):
+        self.pages.append(page)
+
+    def write(self, f):
+        self.out = f.name
+        open(f.name, "wb").close()
+
+
+def test_dividir_pdf(monkeypatch, tmp_path):
+    app = create_app()
+    app.config["UPLOAD_FOLDER"] = tmp_path
+
+    monkeypatch.setattr(split_service, "PdfReader", FakeSplitReader)
+    monkeypatch.setattr(split_service, "PdfWriter", lambda: FakeSplitWriter())
+
+    with app.app_context():
+        f = FileStorage(stream=_fake_pdf_data(), filename="b.pdf")
+        outputs = split_service.dividir_pdf(f)
+
+    assert len(outputs) == 2
+    for path in outputs:
+        assert os.path.exists(path)

--- a/tests/test_subprocess_cmds.py
+++ b/tests/test_subprocess_cmds.py
@@ -1,0 +1,59 @@
+import os
+from io import BytesIO
+from werkzeug.datastructures import FileStorage
+from app import create_app
+from app.services import compress_service, converter_service
+from PyPDF2 import PdfWriter
+
+
+def _simple_pdf():
+    w = PdfWriter()
+    w.add_blank_page(width=10, height=10)
+    buf = BytesIO()
+    w.write(buf)
+    buf.seek(0)
+    return buf
+
+
+def test_compress_runs_ghostscript(monkeypatch, tmp_path):
+    app = create_app()
+    app.config["UPLOAD_FOLDER"] = tmp_path
+    called = {}
+
+    def fake_run(cmd, check=True, timeout=60):
+        called["cmd"] = cmd
+        for part in cmd:
+            if str(part).startswith("-sOutputFile="):
+                open(part.split("=", 1)[1], "wb").close()
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    with app.app_context():
+        file = FileStorage(stream=_simple_pdf(), filename="a.pdf")
+        compress_service.comprimir_pdf(file)
+
+    assert called["cmd"][0] == "gs"
+    assert "-dPDFSETTINGS=/ebook" in called["cmd"]
+
+
+def test_planilha_uses_libreoffice(monkeypatch, tmp_path):
+    app = create_app()
+    app.config["UPLOAD_FOLDER"] = tmp_path
+    called = {}
+
+    def fake_run(cmd, check=True, timeout=120):
+        called["cmd"] = cmd
+        out = (
+            os.path.splitext(os.path.join(cmd[6], os.path.basename(cmd[4])))[0] + ".pdf"
+        )
+        open(out, "wb").close()
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    with app.app_context():
+        csv = BytesIO(b"a,b\n1,2")
+        file = FileStorage(stream=csv, filename="t.csv")
+        converter_service.converter_planilha_para_pdf(file)
+
+    assert "--headless" in called["cmd"]
+    assert called["cmd"][0] == "libreoffice"


### PR DESCRIPTION
## Summary
- enforce style with black and flake8 using pre-commit
- add tests for extracting and splitting pages using mocked PDF classes
- test subprocess commands for compression and libreoffice conversion
- add Playwright E2E test covering merge flow

## Testing
- `pre-commit run --files tests/e2e/test_merge_e2e.py tests/test_pdf_extrair_split.py tests/test_subprocess_cmds.py .pre-commit-config.yaml setup.cfg`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68753ed8e4b8832183c15f3807a4f417