### PR TITLE
Add SortableJS drag-and-drop and style tweaks

### DIFF
--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -24,6 +24,17 @@ document.addEventListener('DOMContentLoaded', () => {
     const spinnerSel = dzEl.dataset.spinner;
     const btnSel     = dzEl.dataset.action;
     const filesContainer = document.querySelector(previewSel);
+
+    if (btnSel.includes('merge') || btnSel.includes('convert') || btnSel.includes('compress')) {
+      filesContainer.classList.add('files-container');
+      if (window.Sortable) {
+        Sortable.create(filesContainer, {
+          animation: 150,
+          ghostClass: 'sortable-ghost',
+          draggable: '.file-wrapper'
+        });
+      }
+    }
     const exts       = dzEl.dataset.extensions ? dzEl.dataset.extensions.split(',') : ['.pdf'];
     const allowMultiple = dzEl.dataset.multiple === 'true';
 

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -631,17 +631,31 @@ canvas#pdf-render { border: 1px solid #ddd; display: block; margin: 0 auto; }
   gap: 12px;
   position: relative;
 }
-.file-wrapper {
-  display: inline-block;
-  vertical-align: top;
-  margin: 8px;
-  padding: 4px;
-  border: 2px solid transparent;
-  cursor: pointer;
+.files-container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  padding: 8px 0;
 }
+
+.file-wrapper {
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+  padding: 8px;
+  width: 140px;
+  cursor: grab;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
+}
+
 .file-wrapper.selected {
   border-color: #00995d;
 }
+
 .file-badge {
   font-size: 0.75em;
   background: #00995d;
@@ -651,36 +665,41 @@ canvas#pdf-render { border: 1px solid #ddd; display: block; margin: 0 auto; }
   margin-bottom: 4px;
   display: inline-block;
 }
+
 .file-name {
   font-size: 0.85em;
   word-break: break-all;
-  max-width: 100px;
+  max-width: 100%;
+  text-align: center;
 }
 
 .file-controls {
   display: flex;
   align-items: center;
   gap: 4px;
+  margin-bottom: 6px;
 }
-.move-left,
-.move-right {
-  background: transparent;
-  border: none;
-  font-size: 1.2em;
+
+.file-controls button {
+  background: #fff;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   cursor: pointer;
-  color: #00995d;
+  transition: background .2s, border-color .2s;
+}
+
+.file-controls button:hover {
+  background: #f5f5f5;
+  border-color: #bbb;
 }
 
 .view-pdf {
-  background: transparent;
-  border: none;
-  cursor: pointer;
-  font-size: 1em;
-  margin-left: 6px;
-}
-
-.view-pdf:hover {
-  color: #007acc;
+  font-size: 1.1em;
 }
 
 .file-wrapper .preview-grid {
@@ -692,8 +711,8 @@ canvas#pdf-render { border: 1px solid #ddd; display: block; margin: 0 auto; }
   position: relative;
   cursor: pointer;
   overflow: hidden;
-  border: 2px solid transparent;
-  border-radius: 4px;
+  border: 1px solid #ddd;
+  border-radius: 6px;
   transition: border-color .2s ease;
 }
 .page-wrapper.selected {
@@ -713,17 +732,20 @@ canvas#pdf-render { border: 1px solid #ddd; display: block; margin: 0 auto; }
   position: absolute;
   top: 4px;
   right: 4px;
-  background: rgba(255,0,0,0.8);
+  background: #e74c3c;
   border: none;
   color: #fff;
   width: 20px;
   height: 20px;
   border-radius: 50%;
-  cursor: pointer;
-  font-weight: bold;
+  font-size: 14px;
   line-height: 18px;
   text-align: center;
-  z-index: 3;
+  cursor: pointer;
+  transition: background .2s;
+}
+.page-remove:hover {
+  background: #c0392b;
 }
 .overlay-spinner {
   position: absolute;
@@ -745,3 +767,7 @@ canvas#pdf-render { border: 1px solid #ddd; display: block; margin: 0 auto; }
 @keyframes spin { to { transform: rotate(360deg); } }
 
 #lista-arquivos { display: none !important; }
+.sortable-ghost {
+  opacity: 0.5;
+  transform: scale(0.95);
+}

--- a/app/templates/compress.html
+++ b/app/templates/compress.html
@@ -11,6 +11,7 @@
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <script src="{{ url_for('static', filename='pdfjs/pdf.min.js') }}"></script>
     <script>pdfjsLib.GlobalWorkerOptions.workerSrc = '{{ url_for("static", filename="pdfjs/pdf.worker.min.js") }}';</script>
+    <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
     <script type="module" src="{{ url_for('static', filename='js/preview.js') }}"></script>
     <script type="module" src="{{ url_for('static', filename='js/script.js') }}"></script>
 </head>

--- a/app/templates/converter.html
+++ b/app/templates/converter.html
@@ -11,6 +11,7 @@
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <script src="{{ url_for('static', filename='pdfjs/pdf.min.js') }}"></script>
     <script>pdfjsLib.GlobalWorkerOptions.workerSrc = '{{ url_for("static", filename="pdfjs/pdf.worker.min.js") }}';</script>
+    <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
     <script type="module" src="{{ url_for('static', filename='js/preview.js') }}"></script>
     <script type="module" src="{{ url_for('static', filename='js/script.js') }}"></script>
 </head>

--- a/app/templates/merge.html
+++ b/app/templates/merge.html
@@ -11,6 +11,7 @@
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <script src="{{ url_for('static', filename='pdfjs/pdf.min.js') }}"></script>
     <script>pdfjsLib.GlobalWorkerOptions.workerSrc = '{{ url_for("static", filename="pdfjs/pdf.worker.min.js") }}';</script>
+    <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
     <script type="module" src="{{ url_for('static', filename='js/preview.js') }}"></script>
     <script type="module" src="{{ url_for('static', filename='js/script.js') }}"></script>
 </head>

--- a/app/templates/split.html
+++ b/app/templates/split.html
@@ -11,6 +11,7 @@
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <script src="{{ url_for('static', filename='pdfjs/pdf.min.js') }}"></script>
     <script>pdfjsLib.GlobalWorkerOptions.workerSrc = '{{ url_for("static", filename="pdfjs/pdf.worker.min.js") }}';</script>
+    <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
     <script type="module" src="{{ url_for('static', filename='js/preview.js') }}"></script>
     <script type="module" src="{{ url_for('static', filename='js/script.js') }}"></script>
 </head>


### PR DESCRIPTION
## Summary
- enable SortableJS on file lists so PDFs can be reordered by drag-and-drop
- refine preview and control styles
- restyle remove button for pages
- include SortableJS library on pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68754b74080c8321b7765dea745815b7