### PR TITLE
Add draggable pages selection for PDF merge

### DIFF
--- a/app/services/merge_service.py
+++ b/app/services/merge_service.py
@@ -76,3 +76,23 @@ def merge_pdfs(file_list):
     with open(out_path, 'wb') as f:
         writer.write(f)
     return out_path
+
+
+def merge_selected_pdfs(file_list, pages_map):
+    writer = PdfWriter()
+    for idx, file in enumerate(file_list):
+        reader = PdfReader(file)
+        pages = pages_map.get(idx)
+        if pages is None:
+            for p in reader.pages:
+                writer.add_page(p)
+        else:
+            for pnum in pages:
+                if 1 <= pnum <= len(reader.pages):
+                    writer.add_page(reader.pages[pnum - 1])
+    out_folder = current_app.config['UPLOAD_FOLDER']
+    out_name   = f"merge_{uuid.uuid4().hex}.pdf"
+    out_path   = os.path.join(out_folder, out_name)
+    with open(out_path, 'wb') as f:
+        writer.write(f)
+    return out_path

--- a/app/static/js/api.js
+++ b/app/static/js/api.js
@@ -90,8 +90,8 @@ export function extractPages(file, pages) {
   }
 
   const form = new FormData();
-  form.append('file', file);
-  form.append('pages', JSON.stringify(pages));
+  form.append('files', file);
+  form.append('pages_0', JSON.stringify(pages));
   xhrRequest('/api/merge', form, blob => {
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -707,6 +707,12 @@ canvas#pdf-render { border: 1px solid #ddd; display: block; margin: 0 auto; }
   grid-template-columns: repeat(auto-fill, minmax(100px,1fr));
   gap: 12px;
 }
+
+.pages-container {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(100px,1fr));
+  gap: 12px;
+}
 .page-wrapper {
   position: relative;
   cursor: pointer;
@@ -840,7 +846,7 @@ canvas#pdf-render { border: 1px solid #ddd; display: block; margin: 0 auto; }
 /* --------------- SORTABLE GHOST --------------- */
 .sortable-ghost {
   opacity: 0.5 !important;
-  transform: scale(0.95) !important;
+  transform: scale(0.98) !important;
 }
 
 button:focus {


### PR DESCRIPTION
## Summary
- allow each preview to track its own selected pages
- make page thumbnails sortable within each file preview
- send selected pages per file to backend and merge accordingly
- implement `merge_selected_pdfs` service and use it in route
- adjust single-file extraction and styles for new containers

## Testing
- `pytest -k "not e2e" -q`

------
https://chatgpt.com/codex/tasks/task_e_687551b621c08321a04f7fa06a56b817