### PR TITLE
Fix non-PDF preview in converter

### DIFF
--- a/app/routes/converter.py
+++ b/app/routes/converter.py
@@ -10,6 +10,17 @@ from .. import limiter
 
 converter_bp = Blueprint('converter', __name__)
 
+# Extensões permitidas para conversão
+ALLOWED_EXTS = {
+    'pdf','doc','docx','odt','rtf','txt','html',
+    'xls','xlsx','ods',
+    'ppt','pptx','odp',
+    'jpg','jpeg','png','bmp','tiff'
+}
+
+def allowed_file(filename):
+    return '.' in filename and filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTS
+
 # Limita este endpoint a no máximo 5 requisições por minuto por IP
 @converter_bp.route('/convert', methods=['POST'])
 @limiter.limit("5 per minute")
@@ -21,6 +32,8 @@ def convert():
     file = request.files['file']
     if file.filename == '':
         return jsonify({'error': 'Nenhum arquivo selecionado.'}), 400
+    if not allowed_file(file.filename):
+        return jsonify({'error': 'Formato n\u00e3o suportado.'}), 400
 
     # Determina a extensão para escolher o serviço correto
     filename = secure_filename(file.filename)

--- a/app/services/converter_service.py
+++ b/app/services/converter_service.py
@@ -33,7 +33,7 @@ def converter_doc_para_pdf(file, modificacoes=None):
     unique_output = os.path.join(upload_folder, f"{uuid.uuid4().hex}.pdf")
 
     # Se for imagem, usa PIL para converter em PDF
-    if file_ext in ['jpg', 'jpeg', 'png']:
+    if file_ext in ['jpg', 'jpeg', 'png', 'bmp', 'tiff']:
         image = Image.open(input_path)
         image = apply_image_modifications(image, modificacoes)
         rgb_image = image.convert('RGB')

--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -16,6 +16,34 @@ import {
   compressFile,
 } from './api.js';
 
+// grupos de extensões
+const PDF_EXTS   = ['pdf'];
+const IMG_EXTS   = ['jpg','jpeg','png','bmp','tiff'];
+const DOC_EXTS   = ['doc','docx','odt','rtf','txt','html'];
+const SHEET_EXTS = ['xls','xlsx','ods'];
+const PPT_EXTS   = ['ppt','pptx','odp'];
+
+function getExt(name) {
+  return name.split('.').pop().toLowerCase();
+}
+
+function showGenericPreview(file, container) {
+  const ext = getExt(file.name);
+  container.innerHTML = '';
+  if (IMG_EXTS.includes(ext)) {
+    const img = document.createElement('img');
+    img.src = URL.createObjectURL(file);
+    img.style.maxWidth = '120px';
+    img.style.margin = '8px';
+    container.appendChild(img);
+  } else {
+    container.innerHTML = `
+      <div class="file-icon">${ext.toUpperCase()}</div>
+      <div class="file-name">${file.name}</div>
+    `;
+  }
+}
+
 function makePagesSortable(containerEl) {
   if (window.Sortable) {
     Sortable.create(containerEl, {
@@ -108,9 +136,15 @@ document.addEventListener('DOMContentLoaded', () => {
           });
 
           filesContainer.appendChild(fw);
-          previewPDF(file, fw.querySelector('.preview-grid'), spinnerSel, btnSel);
-          const pagesContainer = fw.querySelector('.pages-container');
-          if (pagesContainer) makePagesSortable(pagesContainer);
+          const container = fw.querySelector('.preview-grid');
+          const ext = getExt(file.name);
+          if (btnSel.includes('convert') && !PDF_EXTS.includes(ext)) {
+            showGenericPreview(file, container);
+          } else {
+            previewPDF(file, container, spinnerSel, btnSel);
+            const pagesContainer = fw.querySelector('.pages-container');
+            if (pagesContainer) makePagesSortable(pagesContainer);
+          }
         });
       }
     });

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -843,6 +843,12 @@ canvas#pdf-render { border: 1px solid #ddd; display: block; margin: 0 auto; }
   transform: scale(1.1);
 }
 
+.file-icon {
+  font-size: 2rem;
+  color: var(--primary-color);
+  margin-bottom: 6px;
+}
+
 /* --------------- SORTABLE GHOST --------------- */
 .sortable-ghost {
   opacity: 0.5 !important;

--- a/app/templates/converter.html
+++ b/app/templates/converter.html
@@ -31,9 +31,9 @@
                  data-preview="#preview-{{ prefix }}"
                  data-spinner="#spinner-{{ prefix }}"
                  data-action="#btn-{{ prefix }}"
-                 data-extensions=".doc,.docx,.odt,.ods,.odp,.jpg,.jpeg,.png,.csv,.xls,.xlsx"
+                data-extensions=".pdf,.doc,.docx,.odt,.rtf,.txt,.html,.xls,.xlsx,.ods,.ppt,.pptx,.odp,.jpg,.jpeg,.png,.bmp,.tiff"
                  data-multiple="true">
-                <input type="file" id="input-{{ prefix }}" accept=".doc,.docx,.odt,.ods,.odp,.jpg,.jpeg,.png,.csv,.xls,.xlsx" multiple>
+                <input type="file" id="input-{{ prefix }}" accept=".pdf,.doc,.docx,.odt,.rtf,.txt,.html,.xls,.xlsx,.ods,.ppt,.pptx,.odp,.jpg,.jpeg,.png,.bmp,.tiff" multiple>
                 Arraste os arquivos aqui ou clique para selecionar
             </div>
             {{ macros.preview_area('spinner-' ~ prefix, 'preview-' ~ prefix) }}

--- a/app/utils/config_utils.py
+++ b/app/utils/config_utils.py
@@ -5,8 +5,10 @@ from werkzeug.utils import secure_filename
 
 # Extensões de arquivo aceitas para conversão.
 ALLOWED_EXTENSIONS = {
-    'csv', 'docx', 'doc', 'html', 'jpg', 'jpeg', 'png',
-    'xls', 'xlsx', 'odt', 'ods', 'odp',
+    'pdf', 'doc', 'docx', 'odt', 'rtf', 'txt', 'html',
+    'xls', 'xlsx', 'ods',
+    'ppt', 'pptx', 'odp',
+    'jpg', 'jpeg', 'png', 'bmp', 'tiff',
 }
 
 


### PR DESCRIPTION
## Summary
- expand supported extensions in backend and reject unsupported types
- allow BMP/TIFF images in converter service
- show generic preview for non-PDF files
- style generic preview icon
- update converter page file inputs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68755412b3308321a9ef78fa0a408234