### PR TITLE
Add merge shortcut in split page

### DIFF
--- a/app/templates/split.html
+++ b/app/templates/split.html
@@ -54,6 +54,7 @@
     <div class="nav-buttons">
         <a href="{{ url_for('index') }}"><button>Página Inicial</button></a>
         <a href="{{ url_for('converter_page') }}"><button>Conversão</button></a>
+        <a href="{{ url_for('merge_page') }}"><button>Juntar PDFs</button></a>
         <a href="{{ url_for('split_page') }}"><button>Dividir PDF</button></a>
         <a href="{{ url_for('compress_page') }}"><button>Comprimir PDF</button></a>
     </div>


### PR DESCRIPTION
## Summary
- add missing navigation link to merge page in split.html

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875591541bc83219a69868008d76702