### PR TITLE
Implement pagesMap merge flow

### DIFF
--- a/app/routes/merge.py
+++ b/app/routes/merge.py
@@ -1,26 +1,39 @@
-from flask import Blueprint, request, jsonify, send_file, render_template, after_this_request, abort, current_app
+from flask import (
+    Blueprint,
+    request,
+    jsonify,
+    send_file,
+    render_template,
+    after_this_request,
+    abort,
+    current_app,
+)
 import os
-from ..services.merge_service import juntar_pdfs, extrair_paginas_pdf, merge_pdfs, merge_selected_pdfs
+from ..services.merge_service import merge_selected_pdfs
 import json
 from .. import limiter
 
-merge_bp = Blueprint('merge', __name__)
+merge_bp = Blueprint("merge", __name__)
+
 
 # Limita este endpoint a no máximo 3 requisições por minuto por IP
-@merge_bp.route('/merge', methods=['POST'])
+@merge_bp.route("/merge", methods=["POST"])
 @limiter.limit("3 per minute")
 def merge():
-    files = request.files.getlist('files')
+    files = request.files.getlist("files")
     if not files:
-        return jsonify({'error': 'Nenhum arquivo enviado.'}), 400
+        return jsonify({"error": "Nenhum arquivo enviado."}), 400
 
-    pages_map = {}
-    for idx in range(len(files)):
-        key = f'pages_{idx}'
-        if key in request.form:
-            pages_map[idx] = json.loads(request.form[key])
-        else:
-            pages_map[idx] = None
+    pages_json = request.form.get("pagesMap")
+    if not pages_json:
+        return jsonify({"error": "Faltam informações de páginas."}), 400
+    try:
+        pages_map = json.loads(pages_json)
+    except json.JSONDecodeError:
+        return jsonify({"error": "Formato de pagesMap inválido."}), 400
+
+    if len(pages_map) != len(files):
+        return jsonify({"error": "pagesMap não coincide com número de arquivos."}), 400
 
     try:
         output_path = merge_selected_pdfs(files, pages_map)
@@ -34,10 +47,11 @@ def merge():
             return response
 
         return send_file(output_path, as_attachment=True)
-    except Exception as e:
+    except Exception:
         current_app.logger.exception("Erro juntando PDFs")
         abort(500)
 
-@merge_bp.route('/merge', methods=['GET'])
+
+@merge_bp.route("/merge", methods=["GET"])
 def merge_form():
-    return render_template('merge.html')
+    return render_template("merge.html")

--- a/app/services/merge_service.py
+++ b/app/services/merge_service.py
@@ -6,15 +6,16 @@ from PyPDF2 import PdfReader, PdfWriter
 from ..utils.config_utils import ensure_upload_folder_exists, validate_upload
 from ..utils.pdf_utils import apply_pdf_modifications
 
+
 def juntar_pdfs(files, modificacoes=None):
-    upload_folder = current_app.config['UPLOAD_FOLDER']
+    upload_folder = current_app.config["UPLOAD_FOLDER"]
     ensure_upload_folder_exists(upload_folder)
 
     merger = PdfMerger()
     filenames = []
 
     for file in files:
-        filename = validate_upload(file, {'pdf'})
+        filename = validate_upload(file, {"pdf"})
         unique_filename = f"{uuid.uuid4().hex}_{filename}"
         path = os.path.join(upload_folder, unique_filename)
         file.save(path)
@@ -37,10 +38,10 @@ def juntar_pdfs(files, modificacoes=None):
 
 
 def extrair_paginas_pdf(file, pages):
-    upload_folder = current_app.config['UPLOAD_FOLDER']
+    upload_folder = current_app.config["UPLOAD_FOLDER"]
     ensure_upload_folder_exists(upload_folder)
 
-    filename = validate_upload(file, {'pdf'})
+    filename = validate_upload(file, {"pdf"})
     unique_name = f"{uuid.uuid4().hex}_{filename}"
     input_path = os.path.join(upload_folder, unique_name)
     file.save(input_path)
@@ -53,7 +54,7 @@ def extrair_paginas_pdf(file, pages):
 
     output_filename = f"selected_{uuid.uuid4().hex}.pdf"
     output_path = os.path.join(upload_folder, output_filename)
-    with open(output_path, 'wb') as f_out:
+    with open(output_path, "wb") as f_out:
         writer.write(f_out)
 
     try:
@@ -70,19 +71,20 @@ def merge_pdfs(file_list):
         reader = PdfReader(file)
         for page in reader.pages:
             writer.add_page(page)
-    out_folder = current_app.config['UPLOAD_FOLDER']
+    out_folder = current_app.config["UPLOAD_FOLDER"]
     out_name = f"merge_{uuid.uuid4().hex}.pdf"
     out_path = os.path.join(out_folder, out_name)
-    with open(out_path, 'wb') as f:
+    with open(out_path, "wb") as f:
         writer.write(f)
     return out_path
 
 
 def merge_selected_pdfs(file_list, pages_map):
+    """Merge PDFs using a list of page lists (1-based)."""
     writer = PdfWriter()
     for idx, file in enumerate(file_list):
         reader = PdfReader(file)
-        pages = pages_map.get(idx)
+        pages = pages_map[idx] if idx < len(pages_map) else None
         if pages is None:
             for p in reader.pages:
                 writer.add_page(p)
@@ -90,9 +92,9 @@ def merge_selected_pdfs(file_list, pages_map):
             for pnum in pages:
                 if 1 <= pnum <= len(reader.pages):
                     writer.add_page(reader.pages[pnum - 1])
-    out_folder = current_app.config['UPLOAD_FOLDER']
-    out_name   = f"merge_{uuid.uuid4().hex}.pdf"
-    out_path   = os.path.join(out_folder, out_name)
-    with open(out_path, 'wb') as f:
+    out_folder = current_app.config["UPLOAD_FOLDER"]
+    out_name = f"merge_{uuid.uuid4().hex}.pdf"
+    out_path = os.path.join(out_folder, out_name)
+    with open(out_path, "wb") as f:
         writer.write(f)
     return out_path

--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -167,21 +167,25 @@ document.addEventListener('DOMContentLoaded', () => {
         } else {
           const orderedWrappers = Array.from(
             filesContainer.querySelectorAll('.file-wrapper')
-          );
+          ).filter(w => selectedFiles.has(Number(w.dataset.index)));
+
           const form = new FormData();
-          orderedWrappers.forEach(w => {
+          const pagesMap = orderedWrappers.map(w => {
             const idx = Number(w.dataset.index);
-            if (!selectedFiles.has(idx)) return;
             const file = dz.getFiles()[idx];
             form.append('files', file, file.name);
+
             const pagesInOrder = Array.from(
               w.querySelectorAll('.page-wrapper')
             ).map(p => Number(p.dataset.page));
             const selected = pagesInOrder.filter(pg =>
               w.querySelector('.preview-grid').selectedPages.has(pg)
             );
-            form.append('pages_' + idx, JSON.stringify(selected));
+            return selected.length ? selected : pagesInOrder;
           });
+
+          form.append('pagesMap', JSON.stringify(pagesMap));
+
           fetch('/api/merge', {
             method: 'POST',
             headers: { 'X-CSRFToken': getCSRFToken() },

--- a/tests/test_merge_selected_pages.py
+++ b/tests/test_merge_selected_pages.py
@@ -1,0 +1,42 @@
+from io import BytesIO
+from werkzeug.datastructures import FileStorage
+from app import create_app
+from app.services import merge_service
+
+
+class DummyPage:
+    def __init__(self, ident):
+        self.ident = ident
+
+
+class FakeReader:
+    def __init__(self, file):
+        self.pages = [DummyPage(f"{file.filename}-p{i}") for i in range(1, 4)]
+
+
+class FakeWriter:
+    def __init__(self):
+        self.added = []
+
+    def add_page(self, page):
+        self.added.append(page)
+
+    def write(self, f):
+        self.out_path = f.name
+        open(f.name, "wb").close()
+
+
+def test_merge_selected_pdfs_respects_pages(monkeypatch, tmp_path):
+    app = create_app()
+    app.config["UPLOAD_FOLDER"] = tmp_path
+    writer = FakeWriter()
+    monkeypatch.setattr(merge_service, "PdfReader", FakeReader)
+    monkeypatch.setattr(merge_service, "PdfWriter", lambda: writer)
+    with app.app_context():
+        f1 = FileStorage(stream=BytesIO(b"a"), filename="a.pdf")
+        f2 = FileStorage(stream=BytesIO(b"b"), filename="b.pdf")
+        out = merge_service.merge_selected_pdfs([f1, f2], [[2], [1, 3]])
+    ids = [p.ident for p in writer.added]
+    assert ids == ["a.pdf-p2", "b.pdf-p1", "b.pdf-p3"]
+    assert out == writer.out_path
+    assert out.startswith(str(tmp_path))

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -16,25 +16,30 @@ def _simple_pdf():
 def test_referrer_policy_header():
     app = create_app()
     client = app.test_client()
-    resp = client.get('/', base_url='https://localhost')
-    assert resp.headers.get('Referrer-Policy') == 'strict-origin-when-cross-origin'
+    resp = client.get("/", base_url="https://localhost")
+    assert resp.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
 
 
 def test_ajax_request_csrf_success():
     app = create_app()
     client = app.test_client()
 
-    page = client.get('/merge', base_url='https://localhost')
+    page = client.get("/merge", base_url="https://localhost")
     html = page.get_data(as_text=True)
     token = re.search(r'name="csrf-token" content="([^"]+)"', html).group(1)
 
     data = {
-        'files': [
-            ( _simple_pdf(), 'a.pdf'),
-            ( _simple_pdf(), 'b.pdf'),
-        ]
+        "files": [
+            (_simple_pdf(), "a.pdf"),
+            (_simple_pdf(), "b.pdf"),
+        ],
+        "pagesMap": "[[1],[1]]",
     }
-    resp = client.post('/api/merge', data=data, content_type='multipart/form-data',
-                       headers={'X-CSRFToken': token, 'Referer': 'https://localhost/merge'},
-                       base_url='https://localhost')
+    resp = client.post(
+        "/api/merge",
+        data=data,
+        content_type="multipart/form-data",
+        headers={"X-CSRFToken": token, "Referer": "https://localhost/merge"},
+        base_url="https://localhost",
+    )
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- refactor JS merge logic to send single `pagesMap` array
- update merge route to parse `pagesMap`
- adapt merge service to work with list of page lists
- adjust CSRF security test for new API
- add test ensuring merge uses selected pages

## Testing
- `pre-commit run --files app/routes/merge.py app/services/merge_service.py app/static/js/script.js tests/test_merge_selected_pages.py tests/test_security_headers.py`
- `pytest -k 'not e2e' -q`

------
https://chatgpt.com/codex/tasks/task_e_68755aa8b93083218c1d11dc9fab41b4