### PR TITLE
Fix single-file merge pagesMap

### DIFF
--- a/app/static/js/api.js
+++ b/app/static/js/api.js
@@ -91,7 +91,7 @@ export function extractPages(file, pages) {
 
   const form = new FormData();
   form.append('files', file);
-  form.append('pages_0', JSON.stringify(pages));
+  form.append('pagesMap', JSON.stringify([pages]));
   xhrRequest('/api/merge', form, blob => {
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');


### PR DESCRIPTION
## Summary
- ensure single-file extraction uses `pagesMap`
- install Playwright browser to run tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a33b8d7d88321818eb0b37e2142d6