### PR TITLE
Add user hint for page selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,13 @@ Antes de finalizar qualquer operação – como converter, juntar ou dividir PDF
 
 Assim você ajusta o documento antes de efetivar a tarefa desejada.
 
+### Selecionar páginas específicas
+
+Ao juntar ou dividir PDFs, clique sobre cada miniatura para marcar as páginas
+que deseja manter. Utilize o botão "×" em cima da miniatura para removê-la da
+visualização. A lista de páginas selecionadas é enviada para o servidor no campo
+`pagesMap`.
+
 ---
 
 ## 🧪 Testes

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -866,6 +866,13 @@ canvas#pdf-render { border: 1px solid #ddd; display: block; margin: 0 auto; }
   margin-bottom: 6px;
 }
 
+/* Texto auxiliar abaixo do preview */
+.help-text {
+  font-size: 0.9rem;
+  color: #555;
+  margin-top: 8px;
+}
+
 /* --------------- SORTABLE GHOST --------------- */
 .sortable-ghost {
   opacity: 0.5 !important;

--- a/app/templates/macros.html
+++ b/app/templates/macros.html
@@ -1,8 +1,11 @@
-{% macro preview_area(spinner_id, preview_id) %}
+{% macro preview_area(spinner_id, preview_id, hint=None) %}
 <div class="preview-area">
   <div id="{{ spinner_id }}" class="overlay-spinner" aria-hidden="true">
     <div class="loader"></div>
   </div>
   <div id="{{ preview_id }}" class="preview-grid"></div>
+  {% if hint %}
+  <p class="help-text">{{ hint }}</p>
+  {% endif %}
 </div>
 {% endmacro %}

--- a/app/templates/merge.html
+++ b/app/templates/merge.html
@@ -36,7 +36,8 @@
                 <input type="file" id="input-{{ prefix }}" accept=".pdf" multiple>
                 Arraste os arquivos aqui ou clique para selecionar
             </div>
-            {{ macros.preview_area('spinner-' ~ prefix, 'preview-' ~ prefix) }}
+            {{ macros.preview_area('spinner-' ~ prefix, 'preview-' ~ prefix,
+              'Clique na miniatura para selecionar as páginas que serão mantidas. Use o botão \u00d7 para remov\u00ea-las.') }}
             <button id="btn-{{ prefix }}" disabled>Juntar PDFs</button>
         </section>
 

--- a/app/templates/split.html
+++ b/app/templates/split.html
@@ -40,7 +40,8 @@
                 <input type="file" id="input-{{ prefix }}" accept=".pdf" multiple>
                 Arraste os arquivos aqui ou clique para selecionar
             </div>
-            {{ macros.preview_area('spinner-' ~ prefix, 'preview-' ~ prefix) }}
+            {{ macros.preview_area('spinner-' ~ prefix, 'preview-' ~ prefix,
+              'Clique na miniatura para selecionar as páginas que serão mantidas. Use o botão \u00d7 para remov\u00ea-las.') }}
             <button id="btn-{{ prefix }}" disabled>Dividir PDF</button>
         </section>
 


### PR DESCRIPTION
## Summary
- document the pagesMap feature and selection hint in README
- show small hint text in merge and split pages
- support optional hints in preview macro
- style `.help-text`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a378a3f848321aa4b5aacf6182cd8