### PR TITLE
Fix merge page ordering

### DIFF
--- a/app/static/fileDropzone.js
+++ b/app/static/fileDropzone.js
@@ -20,8 +20,13 @@ export function createFileDropzone(options) {
   function moverArquivo(index, offset) {
     const novoIndex = index + offset;
     if (novoIndex < 0 || novoIndex >= files.length) return;
-    const [item] = files.splice(index, 1);
-    files.splice(novoIndex, 0, item);
+    moveFile(index, novoIndex);
+  }
+
+  function moveFile(from, to) {
+    if (from === to || from < 0 || from >= files.length || to < 0 || to >= files.length) return;
+    const [item] = files.splice(from, 1);
+    files.splice(to, 0, item);
     updateInputFiles();
     updateList();
     onChange(files);
@@ -113,6 +118,7 @@ export function createFileDropzone(options) {
   return {
     getFiles: () => files.slice(),
     removeFile: removerArquivo,
+    moveFile,
     clear: () => { files = []; updateInputFiles(); updateList(); onChange(files); }
   };
 }

--- a/app/static/js/preview.js
+++ b/app/static/js/preview.js
@@ -8,9 +8,16 @@ export function initPageSelection(containerEl) {
   containerEl.selectedPages = new Set();
 }
 
-export function getSelectedPages(containerEl) {
+export function getSelectedPages(containerEl, keepOrder = false) {
   if (!containerEl || !containerEl.selectedPages) return [];
-  return Array.from(containerEl.selectedPages).sort((a, b) => a - b);
+  const pages = Array.from(containerEl.selectedPages);
+  if (!keepOrder) {
+    return pages.sort((a, b) => a - b);
+  }
+  const order = Array.from(containerEl.querySelectorAll('.page-wrapper')).map(
+    el => Number(el.dataset.page)
+  );
+  return order.filter(p => pages.includes(p));
 }
 
 // Limpa a seleção de arquivos

--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -68,7 +68,15 @@ document.addEventListener('DOMContentLoaded', () => {
         Sortable.create(filesContainer, {
           animation: 150,
           ghostClass: 'sortable-ghost',
-          draggable: '.file-wrapper'
+          draggable: '.file-wrapper',
+          onEnd: evt => {
+            if (dz && dz.moveFile) {
+              dz.moveFile(evt.oldIndex, evt.newIndex);
+            }
+            Array.from(filesContainer.children).forEach((el, i) => {
+              el.dataset.index = i;
+            });
+          }
         });
       }
     }
@@ -159,7 +167,10 @@ document.addEventListener('DOMContentLoaded', () => {
       if (id.includes('merge')) {
         if (files.length === 1) {
           const fw = filesContainer.querySelector('.file-wrapper');
-          const pages = getSelectedPages(fw.querySelector('.preview-grid'));
+          const pages = getSelectedPages(
+            fw.querySelector('.preview-grid'),
+            true
+          );
           if (!pages.length) {
             return mostrarMensagem('Marque ao menos uma página.', 'erro');
           }
@@ -206,7 +217,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
       if (id.includes('split')) {
         const fw = filesContainer.querySelector('.file-wrapper');
-        const pages = getSelectedPages(fw.querySelector('.preview-grid'));
+        const pages = getSelectedPages(
+          fw.querySelector('.preview-grid'),
+          true
+        );
         if (!pages.length) {
           return mostrarMensagem('Marque ao menos uma página para dividir.', 'erro');
         }


### PR DESCRIPTION
## Summary
- allow ordered page extraction
- handle file reordering when merging
- keep split page order

## Testing
- `pytest --ignore tests/e2e -q`

------
https://chatgpt.com/codex/tasks/task_e_687a41a7298883219661f43566d9ff4b