### PR TITLE
Remove manual file selection for merges

### DIFF
--- a/app/static/js/preview.js
+++ b/app/static/js/preview.js
@@ -1,8 +1,5 @@
 const THUMB_WIDTH = 100;
 
-// Conjunto de índices de arquivos selecionados para o merge
-export const selectedFiles = new Set();
-
 // Inicia o Set de páginas para um container específico
 export function initPageSelection(containerEl) {
   containerEl.selectedPages = new Set();
@@ -20,15 +17,6 @@ export function getSelectedPages(containerEl, keepOrder = false) {
   return order.filter(p => pages.includes(p));
 }
 
-// Limpa a seleção de arquivos
-export function clearFileSelection() {
-  selectedFiles.clear();
-}
-
-// Retorna os File objects escolhidos
-export function getSelectedFiles(allFiles) {
-  return allFiles.filter((f, i) => selectedFiles.has(i));
-}
 
 /**
  * Renderiza as páginas de um PDF dentro do container fornecido.

--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -1,9 +1,6 @@
 import {
   previewPDF,
-  getSelectedPages,
-  clearFileSelection,
-  getSelectedFiles,
-  selectedFiles
+  getSelectedPages
 } from './preview.js';
 import { createFileDropzone } from '../fileDropzone.js';
 import {
@@ -90,7 +87,6 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function renderFiles(files) {
-      clearFileSelection();
       filesContainer.innerHTML = '';
       document.querySelector(btnSel).disabled = true;
 
@@ -113,17 +109,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
         if (btnSel.includes('merge')) {
           fw.classList.add('selected');
-          selectedFiles.add(idx);
-          fw.addEventListener('click', () => {
-            const i = Number(fw.dataset.index);
-            if (selectedFiles.has(i)) {
-              selectedFiles.delete(i);
-              fw.classList.remove('selected');
-            } else {
-              selectedFiles.add(i);
-              fw.classList.add('selected');
-            }
-          });
         }
 
         fw.querySelector('.remove-file').addEventListener('click', e => {
@@ -178,7 +163,7 @@ document.addEventListener('DOMContentLoaded', () => {
         } else {
           const orderedWrappers = Array.from(
             filesContainer.querySelectorAll('.file-wrapper')
-          ).filter(w => selectedFiles.has(Number(w.dataset.index)));
+          );
 
           const form = new FormData();
           const pagesMap = orderedWrappers.map(w => {


### PR DESCRIPTION
## Summary
- simplify preview helper by dropping file selection exports
- auto-mark merge files as selected and include all for merge

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a4b01efe4832183116c86237cabd9