### PR TITLE
Fix missing JS on converter

### DIFF
--- a/app/templates/converter.html
+++ b/app/templates/converter.html
@@ -55,4 +55,8 @@
     </div>
 
     {% include '_preview_modal.html' %}
-</body></html>
+    <!-- carrega o preview e o script principal em módulo -->
+    <script type="module" src="{{ url_for('static', filename='js/preview.js') }}" defer></script>
+    <script type="module" src="{{ url_for('static', filename='js/script.js') }}" defer></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- include preview.js and script.js at the end of converter.html

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a880ad024832183dbb8534b405d89