### PR TITLE
Fix dropzone extension handling and button state

### DIFF
--- a/app/static/fileDropzone.js
+++ b/app/static/fileDropzone.js
@@ -78,7 +78,7 @@ export function createFileDropzone(options) {
 
   function validExtension(file) {
     if (extensions.length === 0) return true;
-    const ext = '.' + file.name.split('.').pop().toLowerCase();
+    const ext = file.name.split('.').pop().toLowerCase();
     return extensions.includes(ext);
   }
 

--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -77,7 +77,9 @@ document.addEventListener('DOMContentLoaded', () => {
         });
       }
     }
-    const exts       = dzEl.dataset.extensions ? dzEl.dataset.extensions.split(',') : ['.pdf'];
+    const exts       = dzEl.dataset.extensions
+      ? dzEl.dataset.extensions.split(',').map(e => e.replace(/^\./, ''))
+      : ['pdf'];
     const allowMultiple = dzEl.dataset.multiple === 'true';
 
     let dz;
@@ -88,7 +90,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function renderFiles(files) {
       filesContainer.innerHTML = '';
-      document.querySelector(btnSel).disabled = true;
+      const btn = document.querySelector(btnSel);
+      btn.disabled = files.length === 0;
 
       if (!files.length) return;
 
@@ -136,6 +139,11 @@ document.addEventListener('DOMContentLoaded', () => {
       multiple:   allowMultiple,
       onChange: renderFiles
     });
+    if (inputEl) {
+      inputEl.addEventListener('change', e => {
+        dz.addFiles(Array.from(e.target.files));
+      });
+    }
 
     const btn = document.querySelector(btnSel);
     btn.addEventListener('click', e => {


### PR DESCRIPTION
## Summary
- allow fileDropzone to match extensions without the dot
- enable action buttons once files are loaded
- sync `<input>` change events with the dropzone

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e2af29f6c8321970efc755b8983b5