### PR TITLE
Persist rotation for merged/split pages

### DIFF
--- a/app/routes/merge.py
+++ b/app/routes/merge.py
@@ -35,8 +35,16 @@ def merge():
     if len(pages_map) != len(files):
         return jsonify({"error": "pagesMap não coincide com número de arquivos."}), 400
 
+    rot_json = request.form.get("rotations")
+    rotations = None
+    if rot_json:
+        try:
+            rotations = json.loads(rot_json)
+        except json.JSONDecodeError:
+            return jsonify({"error": "Formato de rotations inválido."}), 400
+
     try:
-        output_path = merge_selected_pdfs(files, pages_map)
+        output_path = merge_selected_pdfs(files, pages_map, rotations)
 
         @after_this_request
         def cleanup(response):

--- a/app/routes/split.py
+++ b/app/routes/split.py
@@ -1,4 +1,13 @@
-from flask import Blueprint, request, jsonify, send_file, render_template, current_app, after_this_request, abort
+from flask import (
+    Blueprint,
+    request,
+    jsonify,
+    send_file,
+    render_template,
+    current_app,
+    after_this_request,
+    abort,
+)
 from ..services.split_service import dividir_pdf
 from ..services.merge_service import extrair_paginas_pdf
 import json
@@ -7,31 +16,39 @@ import zipfile
 import uuid
 from .. import limiter
 
-split_bp = Blueprint('split', __name__)
+split_bp = Blueprint("split", __name__)
+
 
 # Limita este endpoint a no máximo 5 requisições por minuto por IP
-@split_bp.route('/split', methods=['POST'])
+@split_bp.route("/split", methods=["POST"])
 @limiter.limit("5 per minute")
 def split():
-    if 'file' not in request.files:
-        return jsonify({'error': 'Nenhum arquivo enviado.'}), 400
+    if "file" not in request.files:
+        return jsonify({"error": "Nenhum arquivo enviado."}), 400
 
-    file = request.files['file']
+    file = request.files["file"]
 
-    if file.filename == '':
-        return jsonify({'error': 'Nenhum arquivo selecionado.'}), 400
+    if file.filename == "":
+        return jsonify({"error": "Nenhum arquivo selecionado."}), 400
 
-    if 'pages' in request.form:
+    if "pages" in request.form:
         try:
-            pages = json.loads(request.form['pages'])
+            pages = json.loads(request.form["pages"])
         except json.JSONDecodeError:
-            return jsonify({'error': 'pages deve ser JSON valido'}), 400
+            return jsonify({"error": "pages deve ser JSON valido"}), 400
+
+        rotations = None
+        if "rotations" in request.form:
+            try:
+                rotations = json.loads(request.form["rotations"])
+            except json.JSONDecodeError:
+                return jsonify({"error": "rotations deve ser JSON valido"}), 400
 
         try:
-            output_path = extrair_paginas_pdf(file, [int(p) for p in pages])
+            output_path = extrair_paginas_pdf(file, [int(p) for p in pages], rotations)
 
             @after_this_request
-            def cleanup(response):
+            def cleanup_single(response):
                 try:
                     os.remove(output_path)
                 except OSError:
@@ -43,25 +60,25 @@ def split():
             current_app.logger.exception("Erro extraindo paginas")
             abort(500)
 
-    mods = request.form.get('modificacoes')
+    mods = request.form.get("modificacoes")
     modificacoes = None
     if mods:
         try:
             modificacoes = json.loads(mods)
         except json.JSONDecodeError:
-            return jsonify({'error': 'modificacoes deve ser JSON valido'}), 400
+            return jsonify({"error": "modificacoes deve ser JSON valido"}), 400
 
     try:
         pdf_paths = dividir_pdf(file, modificacoes=modificacoes)
 
         zip_filename = f"{uuid.uuid4().hex}.zip"
-        zip_path = os.path.join(current_app.config['UPLOAD_FOLDER'], zip_filename)
-        with zipfile.ZipFile(zip_path, 'w') as zipf:
+        zip_path = os.path.join(current_app.config["UPLOAD_FOLDER"], zip_filename)
+        with zipfile.ZipFile(zip_path, "w") as zipf:
             for pdf in pdf_paths:
                 zipf.write(pdf, os.path.basename(pdf))
 
         @after_this_request
-        def cleanup(response):
+        def cleanup_zip(response):
             try:
                 os.remove(zip_path)
                 for p in pdf_paths:
@@ -76,6 +93,7 @@ def split():
         current_app.logger.exception("Erro dividindo PDF")
         abort(500)
 
-@split_bp.route('/split', methods=['GET'])
+
+@split_bp.route("/split", methods=["GET"])
 def split_form():
-    return render_template('split.html')
+    return render_template("split.html")

--- a/app/services/merge_service.py
+++ b/app/services/merge_service.py
@@ -37,7 +37,7 @@ def juntar_pdfs(files, modificacoes=None):
     return output_path
 
 
-def extrair_paginas_pdf(file, pages):
+def extrair_paginas_pdf(file, pages, rotations=None):
     upload_folder = current_app.config["UPLOAD_FOLDER"]
     ensure_upload_folder_exists(upload_folder)
 
@@ -48,9 +48,14 @@ def extrair_paginas_pdf(file, pages):
 
     reader = PdfReader(input_path)
     writer = PdfWriter()
-    for p in pages:
+    rotations = rotations or []
+    for idx, p in enumerate(pages):
         if 1 <= p <= len(reader.pages):
-            writer.add_page(reader.pages[p - 1])
+            page = reader.pages[p - 1]
+            angle = rotations[idx] if idx < len(rotations) else 0
+            if angle:
+                page.rotate_clockwise(angle)
+            writer.add_page(page)
 
     output_filename = f"selected_{uuid.uuid4().hex}.pdf"
     output_path = os.path.join(upload_folder, output_filename)
@@ -79,19 +84,28 @@ def merge_pdfs(file_list):
     return out_path
 
 
-def merge_selected_pdfs(file_list, pages_map):
+def merge_selected_pdfs(file_list, pages_map, rotations_map=None):
     """Merge PDFs using a list of page lists (1-based)."""
     writer = PdfWriter()
+    rotations_map = rotations_map or []
     for idx, file in enumerate(file_list):
         reader = PdfReader(file)
         pages = pages_map[idx] if idx < len(pages_map) else None
+        rots = rotations_map[idx] if idx < len(rotations_map) else []
         if pages is None:
-            for p in reader.pages:
+            for j, p in enumerate(reader.pages):
+                angle = rots[j] if j < len(rots) else 0
+                if angle:
+                    p.rotate_clockwise(angle)
                 writer.add_page(p)
         else:
-            for pnum in pages:
+            for j, pnum in enumerate(pages):
                 if 1 <= pnum <= len(reader.pages):
-                    writer.add_page(reader.pages[pnum - 1])
+                    page = reader.pages[pnum - 1]
+                    angle = rots[j] if j < len(rots) else 0
+                    if angle:
+                        page.rotate_clockwise(angle)
+                    writer.add_page(page)
     out_folder = current_app.config["UPLOAD_FOLDER"]
     out_name = f"merge_{uuid.uuid4().hex}.pdf"
     out_path = os.path.join(out_folder, out_name)

--- a/app/static/js/api.js
+++ b/app/static/js/api.js
@@ -83,7 +83,7 @@ export function mergePdfs(files) {
   });
 }
 
-export function extractPages(file, pages) {
+export function extractPages(file, pages, rotations = []) {
   if (!file || !pages.length) {
     mostrarMensagem('Selecione um PDF e páginas válidas.', 'erro');
     return;
@@ -92,6 +92,7 @@ export function extractPages(file, pages) {
   const form = new FormData();
   form.append('files', file);
   form.append('pagesMap', JSON.stringify([pages]));
+  form.append('rotations', JSON.stringify([rotations]));
   xhrRequest('/api/merge', form, blob => {
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');


### PR DESCRIPTION
## Summary
- send page rotation info from frontend when merging or splitting PDFs
- rotate pages server‑side using PyPDF2

## Testing
- `pre-commit run --files app/routes/merge.py app/routes/split.py app/services/merge_service.py app/static/js/api.js app/static/js/script.js`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e3e2ddcd48321a7f2d68376dda7fe