### PR TITLE
Ajusta visualização das miniaturas de PDF

### DIFF
--- a/app/static/js/preview.js
+++ b/app/static/js/preview.js
@@ -1,4 +1,5 @@
-const THUMB_WIDTH = 100;
+// largura base em pixels de cada miniatura do PDF
+const THUMB_WIDTH = 150;
 
 // Inicia o Set de páginas para um container específico
 export function initPageSelection(containerEl) {

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -634,7 +634,7 @@ canvas#pdf-render { border: 1px solid #ddd; display: block; margin: 0 auto; }
 .files-container {
   display: flex;
   flex-wrap: wrap;
-  gap: 12px;
+  gap: 16px;
   padding: 8px 0;
 }
 
@@ -758,6 +758,14 @@ canvas#pdf-render { border: 1px solid #ddd; display: block; margin: 0 auto; }
   border: 1px solid #ddd;
   border-radius: 6px;
   transition: border-color .2s ease;
+  width: auto;
+  max-width: 200px;
+  height: auto;
+}
+.page-wrapper canvas {
+  max-width: 100%;
+  height: auto;
+  display: block;
 }
 .page-wrapper.selected {
   border-color: #00995d;
@@ -884,6 +892,9 @@ canvas#pdf-render { border: 1px solid #ddd; display: block; margin: 0 auto; }
   overflow: hidden;
   border: 1px solid #e0e0e0;
   border-radius: 6px;
+  width: auto;
+  max-width: 200px;
+  height: auto;
 }
 
 .page-remove {
@@ -939,6 +950,9 @@ button:focus {
   border: 1px solid #ddd;
   border-radius: 4px;
   overflow: hidden;
+  width: auto;
+  max-width: 200px;
+  height: auto;
 }
 
 /* ========= Só mostra controles ao passar o mouse ========= */


### PR DESCRIPTION
## Summary
- aumenta `THUMB_WIDTH` para dar mais tamanho às miniaturas
- ajusta CSS de `.page-wrapper` e `.files-container` para acomodar as novas dimensões

## Testing
- `pip install -r requirements.txt`
- `pip install playwright`
- `playwright install chromium`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e4492a8ec83218d375c959af307d4