### PR TITLE
Fix split rotation handling

### DIFF
--- a/app/static/js/api.js
+++ b/app/static/js/api.js
@@ -104,6 +104,29 @@ export function extractPages(file, pages, rotations = []) {
   });
 }
 
+export function splitPages(file, pages, rotations = []) {
+  if (!file || !pages.length) {
+    mostrarMensagem('Selecione um PDF e páginas válidas.', 'erro');
+    return;
+  }
+
+  const form = new FormData();
+  form.append('file', file);
+  form.append('pages', JSON.stringify(pages));
+  form.append('rotations', JSON.stringify(rotations));
+
+  xhrRequest('/api/split', form, blob => {
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'pdf_dividido.pdf';
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    mostrarMensagem('PDF dividido com sucesso!', 'sucesso');
+  });
+}
+
 export function splitFile(file) {
   if (!file) {
     mostrarMensagem('Selecione um PDF.', 'erro');

--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -9,7 +9,7 @@ import {
 } from './utils.js';
 import {
   convertFiles,
-  extractPages,
+  splitPages,
   compressFile,
 } from './api.js';
 
@@ -165,7 +165,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const pw = container.querySelector(`.page-wrapper[data-page="${pg}"]`);
             return Number(pw.dataset.rotation || 0);
           });
-          extractPages(files[0], pages, rotations);
+          splitPages(files[0], pages, rotations);
         } else {
           const orderedWrappers = Array.from(
             filesContainer.querySelectorAll('.file-wrapper')


### PR DESCRIPTION
## Summary
- add a splitPages helper to API client
- call splitPages instead of extractPages when selecting pages from a single PDF

## Testing
- `pre-commit run --files app/static/js/api.js app/static/js/script.js`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e49ca0b5883218448aaf20c591d1c