### PR TITLE
Add per-page rotation support to splitting

### DIFF
--- a/app/services/merge_service.py
+++ b/app/services/merge_service.py
@@ -54,7 +54,7 @@ def extrair_paginas_pdf(file, pages, rotations=None):
             page = reader.pages[p - 1]
             angle = rotations[idx] if idx < len(rotations) else 0
             if angle:
-                page.rotate_clockwise(angle)
+                page.rotate(angle)
             writer.add_page(page)
 
     output_filename = f"selected_{uuid.uuid4().hex}.pdf"
@@ -96,7 +96,7 @@ def merge_selected_pdfs(file_list, pages_map, rotations_map=None):
             for j, p in enumerate(reader.pages):
                 angle = rots[j] if j < len(rots) else 0
                 if angle:
-                    p.rotate_clockwise(angle)
+                    p.rotate(angle)
                 writer.add_page(p)
         else:
             for j, pnum in enumerate(pages):
@@ -104,7 +104,7 @@ def merge_selected_pdfs(file_list, pages_map, rotations_map=None):
                     page = reader.pages[pnum - 1]
                     angle = rots[j] if j < len(rots) else 0
                     if angle:
-                        page.rotate_clockwise(angle)
+                        page.rotate(angle)
                     writer.add_page(page)
     out_folder = current_app.config["UPLOAD_FOLDER"]
     out_name = f"merge_{uuid.uuid4().hex}.pdf"

--- a/app/services/split_service.py
+++ b/app/services/split_service.py
@@ -47,7 +47,7 @@ def dividir_pdf(file, pages=None, rotations=None, modificacoes=None):
             page = reader.pages[pageno - 1]
             angle = rotations[idx] if idx < len(rotations) else 0
             if angle:
-                page.rotate_clockwise(angle)
+                page.rotate(angle)
 
             writer = PdfWriter()
             writer.add_page(page)

--- a/tests/test_modificacoes.py
+++ b/tests/test_modificacoes.py
@@ -50,3 +50,15 @@ def test_split_crop(app):
         assert (w, h) == (5, 5)
         for p in outputs:
             os.remove(p)
+
+
+def test_split_rotation(app):
+    with app.app_context():
+        buf = _simple_pdf(size=(10, 20))
+        file = FileStorage(stream=buf, filename="a.pdf")
+        outputs = split_service.dividir_pdf(file, pages=[1], rotations=[90])
+        reader = PdfReader(outputs[0])
+        rotation = reader.pages[0].get('/Rotate')
+        assert rotation == 90
+        for p in outputs:
+            os.remove(p)


### PR DESCRIPTION
## Summary
- rotate pages during PDF split by using `page.rotate`
- update merge service to use `rotate`
- test rotations in `split_service`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e64960fbc8321ac9f7038323beab3