### PR TITLE
Fix PDF split rotation

### DIFF
--- a/app/services/split_service.py
+++ b/app/services/split_service.py
@@ -47,7 +47,11 @@ def dividir_pdf(file, pages=None, rotations=None, modificacoes=None):
             page = reader.pages[pageno - 1]
             angle = rotations[idx] if idx < len(rotations) else 0
             if angle:
-                page.rotate(angle)
+                # aplica rotação de fato antes de adicionar a página
+                try:
+                    page.rotate_clockwise(angle)
+                except Exception:
+                    page.rotate(angle)
 
             writer = PdfWriter()
             writer.add_page(page)


### PR DESCRIPTION
## Summary
- apply page rotation correctly when splitting PDFs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e69518a3c83218e2f2d5770352de0