### PR TITLE
Preserve page rotations during PDF merge and compress

### DIFF
--- a/app/routes/compress.py
+++ b/app/routes/compress.py
@@ -27,8 +27,16 @@ def compress():
         except json.JSONDecodeError:
             return jsonify({'error': 'modificacoes deve ser JSON valido'}), 400
 
+    rot_json = request.form.get('rotations')
+    rotations = None
+    if rot_json:
+        try:
+            rotations = json.loads(rot_json)
+        except json.JSONDecodeError:
+            return jsonify({'error': 'rotations deve ser JSON valido'}), 400
+
     try:
-        output_path = comprimir_pdf(file, modificacoes=modificacoes)
+        output_path = comprimir_pdf(file, rotations=rotations, modificacoes=modificacoes)
 
         @after_this_request
         def cleanup(response):

--- a/app/services/merge_service.py
+++ b/app/services/merge_service.py
@@ -54,7 +54,10 @@ def extrair_paginas_pdf(file, pages, rotations=None):
             page = reader.pages[p - 1]
             angle = rotations[idx] if idx < len(rotations) else 0
             if angle:
-                page.rotate(angle)
+                try:
+                    page.rotate_clockwise(angle)
+                except Exception:
+                    page.rotate(angle)
             writer.add_page(page)
 
     output_filename = f"selected_{uuid.uuid4().hex}.pdf"
@@ -96,7 +99,10 @@ def merge_selected_pdfs(file_list, pages_map, rotations_map=None):
             for j, p in enumerate(reader.pages):
                 angle = rots[j] if j < len(rots) else 0
                 if angle:
-                    p.rotate(angle)
+                    try:
+                        p.rotate_clockwise(angle)
+                    except Exception:
+                        p.rotate(angle)
                 writer.add_page(p)
         else:
             for j, pnum in enumerate(pages):
@@ -104,7 +110,10 @@ def merge_selected_pdfs(file_list, pages_map, rotations_map=None):
                     page = reader.pages[pnum - 1]
                     angle = rots[j] if j < len(rots) else 0
                     if angle:
-                        page.rotate(angle)
+                        try:
+                            page.rotate_clockwise(angle)
+                        except Exception:
+                            page.rotate(angle)
                     writer.add_page(page)
     out_folder = current_app.config["UPLOAD_FOLDER"]
     out_name = f"merge_{uuid.uuid4().hex}.pdf"

--- a/app/static/js/api.js
+++ b/app/static/js/api.js
@@ -147,7 +147,7 @@ export function splitFile(file) {
   });
 }
 
-export function compressFile(file) {
+export function compressFile(file, rotations = []) {
   if (!file) {
     mostrarMensagem('Selecione um PDF.', 'erro');
     return;
@@ -155,6 +155,7 @@ export function compressFile(file) {
 
   const form = new FormData();
   form.append('file', file);
+  form.append('rotations', JSON.stringify(rotations));
   xhrRequest('/api/compress', form, blob => {
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');

--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -248,7 +248,14 @@ document.addEventListener('DOMContentLoaded', () => {
       }
 
       if (id.includes('compress')) {
-        files.forEach(f => compressFile(f));
+        const wrappers = Array.from(
+          filesContainer.querySelectorAll('.file-wrapper')
+        );
+        const rotations = wrappers.map(w => {
+          const pages = w.querySelectorAll('.page-wrapper');
+          return Array.from(pages).map(p => Number(p.dataset.rotation || 0));
+        });
+        files.forEach((file, i) => compressFile(file, rotations[i] || []));
         return;
       }
     });


### PR DESCRIPTION
## Summary
- propagate page rotations for compress action
- send rotation info via API to backend
- apply per-page rotations when compressing
- rotate pages clockwise in merge service

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e6dcf29548321b4b488449adf586a