### PR TITLE
Ensure CSRF header for Ajax

### DIFF
--- a/app/static/js/api.js
+++ b/app/static/js/api.js
@@ -8,6 +8,8 @@ function xhrRequest(url, formData, onSuccess) {
   xhr.open('POST', url);
   xhr.responseType = 'blob';
   xhr.setRequestHeader('X-CSRFToken', getCSRFToken());
+  xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+  xhr.withCredentials = true;
 
   xhr.upload.onprogress = e => {
     if (e.lengthComputable) {
@@ -158,8 +160,10 @@ export function compressFile(file, rotations = []) {
   form.append('rotations', JSON.stringify(rotations));
   return fetch('/api/compress', {
     method: 'POST',
+    credentials: 'same-origin',
     headers: {
-      'X-CSRFToken': getCSRFToken()
+      'X-CSRFToken': getCSRFToken(),
+      'X-Requested-With': 'XMLHttpRequest'
     },
     body: form
   })

--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -199,7 +199,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
           fetch('/api/merge', {
             method: 'POST',
-            headers: { 'X-CSRFToken': getCSRFToken() },
+            credentials: 'same-origin',
+            headers: {
+              'X-CSRFToken': getCSRFToken(),
+              'X-Requested-With': 'XMLHttpRequest'
+            },
             body: form
           })
             .then(res => res.blob())
@@ -232,7 +236,11 @@ document.addEventListener('DOMContentLoaded', () => {
         form.append('rotations', JSON.stringify(rotations));
         fetch('/api/split', {
           method: 'POST',
-          headers: { 'X-CSRFToken': getCSRFToken() },
+          credentials: 'same-origin',
+          headers: {
+            'X-CSRFToken': getCSRFToken(),
+            'X-Requested-With': 'XMLHttpRequest'
+          },
           body: form
         })
           .then(res => res.blob())


### PR DESCRIPTION
## Summary
- include `X-Requested-With` header and send cookies for all ajax requests
- leave helper to send CSRF token as is

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e73d36654832197fcbb3c1350e6c2