### PR TITLE
Fix rotate button triggering CSRF error

### DIFF
--- a/app/static/js/preview.js
+++ b/app/static/js/preview.js
@@ -56,8 +56,8 @@ export async function previewPDF(file, container, spinnerSel, btnSel) {
     wrapper.dataset.rotation = 0;
     wrapper.innerHTML = `
       <div class="file-controls">
-        <button class="remove-file" title="Remover página">×</button>
-        <button class="rotate-page" title="Girar página">⟳</button>
+        <button type="button" class="remove-file" title="Remover página">×</button>
+        <button type="button" class="rotate-page" title="Girar página">⟳</button>
       </div>
       <div class="page-badge">Pg ${i}</div>
       <canvas data-page="${i}"></canvas>

--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -102,9 +102,9 @@ document.addEventListener('DOMContentLoaded', () => {
         fw.dataset.index = idx;
         fw.innerHTML = `
           <div class="file-controls">
-            <button class="view-pdf" aria-label="Visualizar PDF">\uD83D\uDD0D</button>
+            <button type="button" class="view-pdf" aria-label="Visualizar PDF">\uD83D\uDD0D</button>
             <span class="file-badge">Arquivo ${idx + 1}</span>
-            <button class="remove-file" aria-label="Remover arquivo">×</button>
+            <button type="button" class="remove-file" aria-label="Remover arquivo">×</button>
           </div>
           <div class="file-name">${file.name}</div>
           <div class="preview-grid"></div>


### PR DESCRIPTION
## Summary
- avoid form submission when rotating or removing pages
- button actions now specify `type="button"`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e7915ab308321a9db3ebaff24d72e