### PR TITLE
Show allowed extensions in converter

### DIFF
--- a/app/templates/converter.html
+++ b/app/templates/converter.html
@@ -36,6 +36,10 @@
                 <input type="file" id="input-{{ prefix }}" accept=".pdf,.doc,.docx,.odt,.rtf,.txt,.html,.xls,.xlsx,.ods,.ppt,.pptx,.odp,.jpg,.jpeg,.png,.bmp,.tiff" multiple>
                 Arraste os arquivos aqui ou clique para selecionar
             </div>
+            <p class="subtitulo">
+              Extensões aceitas: PDF, DOC, DOCX, ODT, RTF, TXT, HTML, XLS,
+              XLSX, ODS, PPT, PPTX, ODP, JPG, JPEG, PNG, BMP, TIFF
+            </p>
             {{ macros.preview_area('spinner-' ~ prefix, 'preview-' ~ prefix) }}
             <button id="converter-btn" disabled>Converter Todos</button>
         </section>


### PR DESCRIPTION
## Summary
- add notice listing supported extensions in converter page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687e7c7d2bd483219745dcad3f2abdc0