### PR TITLE
Ban PDF input from converter

### DIFF
--- a/app/routes/converter.py
+++ b/app/routes/converter.py
@@ -40,6 +40,8 @@ def convert():
     if '.' not in filename:
         return jsonify({'error': 'Extensão de arquivo inválida.'}), 400
     ext = filename.rsplit('.', 1)[1].lower()
+    if ext == 'pdf':
+        return jsonify({'error': 'Envio de arquivos PDF não permitido nesta rota.'}), 400
 
     mods = request.form.get('modificacoes')
     modificacoes = None

--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -77,9 +77,12 @@ document.addEventListener('DOMContentLoaded', () => {
         });
       }
     }
-    const exts       = dzEl.dataset.extensions
+    let exts = dzEl.dataset.extensions
       ? dzEl.dataset.extensions.split(',').map(e => e.replace(/^\./, ''))
       : ['pdf'];
+    if (btnSel.includes('convert')) {
+      exts = exts.filter(e => e !== 'pdf');
+    }
     const allowMultiple = dzEl.dataset.multiple === 'true';
 
     let dz;

--- a/app/templates/converter.html
+++ b/app/templates/converter.html
@@ -31,13 +31,13 @@
                  data-preview="#preview-{{ prefix }}"
                  data-spinner="#spinner-{{ prefix }}"
                 data-action="#converter-btn"
-                data-extensions=".pdf,.doc,.docx,.odt,.rtf,.txt,.html,.xls,.xlsx,.ods,.ppt,.pptx,.odp,.jpg,.jpeg,.png,.bmp,.tiff"
+                data-extensions=".doc,.docx,.odt,.rtf,.txt,.html,.xls,.xlsx,.ods,.ppt,.pptx,.odp,.jpg,.jpeg,.png,.bmp,.tiff"
                  data-multiple="true">
-                <input type="file" id="input-{{ prefix }}" accept=".pdf,.doc,.docx,.odt,.rtf,.txt,.html,.xls,.xlsx,.ods,.ppt,.pptx,.odp,.jpg,.jpeg,.png,.bmp,.tiff" multiple>
+                <input type="file" id="input-{{ prefix }}" accept=".doc,.docx,.odt,.rtf,.txt,.html,.xls,.xlsx,.ods,.ppt,.pptx,.odp,.jpg,.jpeg,.png,.bmp,.tiff" multiple>
                 Arraste os arquivos aqui ou clique para selecionar
             </div>
             <p class="subtitulo">
-              Extensões aceitas: PDF, DOC, DOCX, ODT, RTF, TXT, HTML, XLS,
+              Extensões aceitas: DOC, DOCX, ODT, RTF, TXT, HTML, XLS,
               XLSX, ODS, PPT, PPTX, ODP, JPG, JPEG, PNG, BMP, TIFF
             </p>
             {{ macros.preview_area('spinner-' ~ prefix, 'preview-' ~ prefix) }}


### PR DESCRIPTION
## Summary
- remove .pdf from converter page's accepted extensions
- filter PDF from drag-and-drop extension list
- reject PDF uploads on convert endpoint

## Testing
- `pytest -k 'not e2e' -q`

------
https://chatgpt.com/codex/tasks/task_e_687e7e7ecfa083218f6d46a440fe6358