### PR TITLE
Fix compress rotation support

### DIFF
--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -259,14 +259,14 @@ document.addEventListener('DOMContentLoaded', () => {
       }
 
       if (id.includes('compress')) {
-        const wrappers = Array.from(
-          filesContainer.querySelectorAll('.file-wrapper')
-        );
-        const rotations = wrappers.map(w => {
-          const pages = w.querySelectorAll('.page-wrapper');
-          return Array.from(pages).map(p => Number(p.dataset.rotation || 0));
+        // para cada wrapper capturamos o índice e a rotação
+        const wrappers = Array.from(filesContainer.querySelectorAll('.file-wrapper'));
+        wrappers.forEach(w => {
+          const idx      = +w.dataset.index;
+          const file     = dz.getFiles()[idx];
+          const rotation = Number(w.dataset.rotation || 0);
+          compressFile(file, rotation);
         });
-        files.forEach((file, i) => compressFile(file, rotations[i] || []));
         return;
       }
     });


### PR DESCRIPTION
## Summary
- allow compress API to accept rotation as `modificacoes`
- forward each wrapper's rotation to the compress request

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e82318670832194bdbff6a739bde4