### PR TITLE
Fix API prefix

### DIFF
--- a/app/static/js/api.js
+++ b/app/static/js/api.js
@@ -1,6 +1,6 @@
 import { getCSRFToken, mostrarMensagem, mostrarLoading, atualizarProgresso, resetarProgresso } from './utils.js';
 
-const API_BASE = '/api/pdf';
+export const API_BASE = '/api/pdf';
 
 export function uploadPdf({ url, files = [], pagesMap, rotations, modifications, onProgress }) {
   return new Promise((resolve, reject) => {

--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -2,8 +2,10 @@ import { getSelectedPages } from './preview.js';
 import { mostrarMensagem } from './utils.js';
 import {
   convertFiles,
+  mergePdfs,
   splitPages,
   compressFile,
+  API_BASE,
 } from './api.js';
 import { PdfWidget } from './pdf-widget.js';
 


### PR DESCRIPTION
## Summary
- export `API_BASE` constant from `api.js`
- import `mergePdfs` and `API_BASE` in `script.js`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f78a66828832182060db8e4ade06d