### PR TITLE
Fix non PDF preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Antes de finalizar qualquer operação – como converter, juntar ou dividir PDF
 
 - Lista dos arquivos selecionados;
 - Visualização do PDF à direita quando houver um;
+- Para documentos ou imagens, apenas o nome/ícone é mostrado (nenhum PDF é carregado);
 - Ações de **Girar** e **Recortar** para cada item;
 - Botões para confirmar ou cancelar o processamento.
 

--- a/app/static/js/preview.js
+++ b/app/static/js/preview.js
@@ -36,6 +36,17 @@ export async function previewPDF(file, container, spinnerSel, btnSel) {
   const btnEl     = document.querySelector(btnSel);
   if (!containerEl || !spinnerEl || !btnEl) return;
 
+  const ext = file.name.split('.').pop().toLowerCase();
+  if (ext !== 'pdf') {
+    containerEl.classList.add('file-wrapper');
+    containerEl.innerHTML = `
+      <span class="file-badge">${ext}</span>
+      <span class="file-name">${file.name}</span>
+    `;
+    btnEl.disabled = false;
+    return;
+  }
+
   // armazena seleção própria do container
   initPageSelection(containerEl);
 


### PR DESCRIPTION
## Summary
- filter preview for `.pdf` files only
- mention that non-PDFs will only show name/icon in the preview

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f7dd864788321afab3ee4454af1a4