### PR TITLE
Fix file upload field name

### DIFF
--- a/app/static/js/api.js
+++ b/app/static/js/api.js
@@ -8,7 +8,12 @@ export function uploadPdf({ url, files = [], pagesMap, rotations, modifications,
     resetarProgresso();
 
     const formData = new FormData();
-    files.forEach(f => formData.append('files', f));
+    const useFilesField = url.includes('/merge') || files.length > 1;
+    if (useFilesField) {
+      files.forEach(f => formData.append('files', f));
+    } else if (files.length === 1) {
+      formData.append('file', files[0]);
+    }
     if (pagesMap) formData.append('pagesMap', JSON.stringify(pagesMap));
     if (rotations) formData.append('rotations', JSON.stringify(rotations));
     if (modifications) formData.append('modificacoes', JSON.stringify(modifications));


### PR DESCRIPTION
## Summary
- detect merge URL in frontend helper
- use `file` field when uploading single files

## Testing
- `pre-commit run --files app/static/js/api.js`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f7f9629608321b9e240ce9ffd9441