### PR TITLE
Implement front-end cleanup of converted files

### DIFF
--- a/app/static/js/api.js
+++ b/app/static/js/api.js
@@ -65,22 +65,24 @@ export function uploadPdf({ url, files = [], pagesMap, rotations, modifications,
 export function convertFiles(files) {
   if (!files.length) {
     mostrarMensagem('Adicione pelo menos um arquivo para converter.', 'erro');
-    return;
+    return Promise.resolve();
   }
 
-  files.forEach(file => {
+  const tasks = files.map(file =>
     uploadPdf({ url: `${API_BASE}/convert`, files: [file] })
       .then(blob => {
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = file.name.replace(/\.[^/.]+$/, '') + '.pdf';
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-      mostrarMensagem(`Arquivo "${file.name}" convertido com sucesso!`);
-      });
-  });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = file.name.replace(/\.[^/.]+$/, '') + '.pdf';
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        mostrarMensagem(`Arquivo "${file.name}" convertido com sucesso!`);
+      })
+  );
+
+  return Promise.all(tasks);
 }
 
 export function mergePdfs(files) {

--- a/app/static/js/pdf-widget.js
+++ b/app/static/js/pdf-widget.js
@@ -9,12 +9,15 @@ export class PdfWidget {
     this.btnSel = btnSel;
     this.action = action;
     this.dz = null;
+    this.previewEl = null;
   }
 
   init() {
     const inputEl = this.dropzoneEl.querySelector('input[type="file"]');
     const previewEl = document.querySelector(this.previewSel);
     const btn = document.querySelector(this.btnSel);
+
+    this.previewEl = previewEl;
 
     const exts = this.dropzoneEl.dataset.extensions
       ? this.dropzoneEl.dataset.extensions.split(',').map(e => e.replace(/^\./, ''))
@@ -26,25 +29,41 @@ export class PdfWidget {
       input: inputEl,
       extensions: exts,
       multiple: allowMultiple,
-      onChange: files => this.renderFiles(files, previewEl)
+      onChange: files => this.renderFiles(files)
     });
 
     if (btn) {
       btn.addEventListener('click', e => {
         e.preventDefault();
-        if (this.action) this.action(this.dz.getFiles(), previewEl);
+        if (this.action) this.action(this.dz.getFiles(), this.previewEl, this);
       });
     }
   }
 
-  renderFiles(files, previewEl) {
-    if (!previewEl) return;
-    previewEl.innerHTML = '';
-    files.forEach(file => {
+  renderFiles(files) {
+    if (!this.previewEl) return;
+    this.previewEl.innerHTML = '';
+    files.forEach((file, idx) => {
       const container = document.createElement('div');
       container.classList.add('preview-wrapper');
-      previewEl.appendChild(container);
+      this.previewEl.appendChild(container);
       previewPDF(file, container, this.spinnerSel, this.btnSel);
+
+      const removeBtn = document.createElement('button');
+      removeBtn.type = 'button';
+      removeBtn.className = 'remove-file';
+      removeBtn.dataset.idx = idx;
+      removeBtn.textContent = '×';
+      removeBtn.addEventListener('click', e => {
+        e.stopPropagation();
+        this.dz.removeFile(parseInt(removeBtn.dataset.idx, 10));
+      });
+      container.prepend(removeBtn);
     });
+  }
+
+  clear() {
+    if (this.dz) this.dz.clear();
+    if (this.previewEl) this.previewEl.innerHTML = '';
   }
 }

--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -26,10 +26,12 @@ function makePagesSortable(containerEl) {
   }
 }
 
-function handleAction(btn, files, container) {
+function handleAction(btn, files, container, widget) {
   const id = btn.id;
   if (id.includes('convert')) {
-    convertFiles(files);
+    convertFiles(files).then(() => {
+      if (widget) widget.clear();
+    });
     return;
   }
 
@@ -71,9 +73,9 @@ document.addEventListener('DOMContentLoaded', () => {
       previewSel: dzEl.dataset.preview,
       spinnerSel: dzEl.dataset.spinner,
       btnSel: dzEl.dataset.action,
-      action: (files, previewEl) => {
+      action: (files, previewEl, w) => {
         const btn = document.querySelector(dzEl.dataset.action);
-        handleAction(btn, files, previewEl);
+        handleAction(btn, files, previewEl, w);
       }
     });
     widget.init();


### PR DESCRIPTION
## Summary
- allow clearing previews after converting files
- add remove buttons for each preview item
- expose clear function on PdfWidget and update convertFiles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f99127c708321b815fde8d6c1eac3