### PR TITLE
Align delete button with Dropzone widget

### DIFF
--- a/app/static/js/pdf-widget.js
+++ b/app/static/js/pdf-widget.js
@@ -49,16 +49,6 @@ export class PdfWidget {
       this.previewEl.appendChild(container);
       previewPDF(file, container, this.spinnerSel, this.btnSel);
 
-      const removeBtn = document.createElement('button');
-      removeBtn.type = 'button';
-      removeBtn.className = 'remove-file';
-      removeBtn.dataset.idx = idx;
-      removeBtn.textContent = '×';
-      removeBtn.addEventListener('click', e => {
-        e.stopPropagation();
-        this.dz.removeFile(parseInt(removeBtn.dataset.idx, 10));
-      });
-      container.prepend(removeBtn);
     });
   }
 

--- a/app/templates/converter.html
+++ b/app/templates/converter.html
@@ -12,7 +12,6 @@
     <script src="{{ url_for('static', filename='pdfjs/pdf.min.js') }}"></script>
     <script src="{{ url_for('static', filename='js/pdf-config.js') }}"></script>
     <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
-    <script type="module" src="{{ url_for('static', filename='js/script.js') }}" defer></script>
 </head>
 <body>
     <header class="header-flex">
@@ -58,5 +57,7 @@
     </div>
 
     {% include '_preview_modal.html' %}
+    <script src="{{ url_for('static', filename='fileDropzone.js') }}" defer></script>
+    <script type="module" src="{{ url_for('static', filename='js/script.js') }}" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove direct delete button from pdf-widget
- load fileDropzone before main script on the converter page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f9db8679c8321a690e55de9412d29