### PR TITLE
Enable deleting uploaded files on converter page

### DIFF
--- a/app/static/js/pdf-widget.js
+++ b/app/static/js/pdf-widget.js
@@ -13,9 +13,12 @@ export class PdfWidget {
   }
 
   init() {
-    const inputEl = this.dropzoneEl.querySelector('input[type="file"]');
+    const inputEl  = this.dropzoneEl.querySelector('input[type="file"]');
     const previewEl = document.querySelector(this.previewSel);
-    const btn = document.querySelector(this.btnSel);
+    const listSel  = this.dropzoneEl.dataset.list;
+    const listEl   = listSel ? document.querySelector(listSel) : null;
+    const btn      = document.querySelector(this.btnSel);
+    if (btn) btn.disabled = true;
 
     this.previewEl = previewEl;
 
@@ -27,9 +30,13 @@ export class PdfWidget {
     this.dz = createFileDropzone({
       dropzone: this.dropzoneEl,
       input: inputEl,
+      list: listEl,
       extensions: exts,
       multiple: allowMultiple,
-      onChange: files => this.renderFiles(files)
+      onChange: files => {
+        this.renderFiles(files);
+        if (btn) btn.disabled = files.length === 0;
+      }
     });
 
     if (btn) {

--- a/app/templates/converter.html
+++ b/app/templates/converter.html
@@ -28,12 +28,14 @@
             <div id="dropzone-{{ prefix }}" class="dropzone"
                  data-preview="#preview-{{ prefix }}"
                  data-spinner="#spinner-{{ prefix }}"
-                data-action="#converter-btn"
-                data-extensions=".doc,.docx,.odt,.rtf,.txt,.html,.xls,.xlsx,.ods,.ppt,.pptx,.odp,.jpg,.jpeg,.png,.bmp,.tiff"
+                 data-action="#converter-btn"
+                 data-list="#lista-arquivos"
+                 data-extensions=".doc,.docx,.odt,.rtf,.txt,.html,.xls,.xlsx,.ods,.ppt,.pptx,.odp,.jpg,.jpeg,.png,.bmp,.tiff"
                  data-multiple="true">
                 <input type="file" id="input-{{ prefix }}" accept=".doc,.docx,.odt,.rtf,.txt,.html,.xls,.xlsx,.ods,.ppt,.pptx,.odp,.jpg,.jpeg,.png,.bmp,.tiff" multiple>
                 Arraste os arquivos aqui ou clique para selecionar
             </div>
+            <ul id="lista-arquivos"></ul>
             <p class="subtitulo">
               Extensões aceitas: DOC, DOCX, ODT, RTF, TXT, HTML, XLS,
               XLSX, ODS, PPT, PPTX, ODP, JPG, JPEG, PNG, BMP, TIFF


### PR DESCRIPTION
## Summary
- add file list to converter.html so Dropzone can show actions
- allow PdfWidget to hook a list and disable the action button while empty

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fa028e878832180bea1cbd9af5fdc