### PR TITLE
Remove deprecated file list logic

### DIFF
--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -82,31 +82,3 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 });
 
-// Legacy support for direct file input flows
-let arquivosSelecionados = [];
-
-function atualizarLista() {
-  const lista = document.getElementById('lista-arquivos');
-  if (!lista) return;
-  lista.innerHTML = arquivosSelecionados.map(f => `<li>${f.name}</li>`).join('');
-}
-
-function adicionarArquivo() {
-  const input = document.getElementById('file-input');
-  if (!input) return;
-  const novosArquivos = Array.from(input.files);
-  arquivosSelecionados.push(...novosArquivos);
-  input.value = '';
-  atualizarLista();
-}
-
-function adicionarArquivoSplit() {
-  const input = document.getElementById('file-input');
-  if (!input) return;
-  const novosArquivos = Array.from(input.files);
-  arquivosSelecionados = [];
-  arquivosSelecionados.push(...novosArquivos);
-  input.value = '';
-  atualizarLista();
-}
-


### PR DESCRIPTION
## Summary
- drop legacy file list handlers from script.js

## Testing
- `pre-commit run --files app/static/js/script.js app/templates/converter.html`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fb3ca88a88321af6b6489815a9e3c