### PR TITLE
Improve accepted extensions display

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -73,6 +73,25 @@ header {
     margin-top: 4px;
 }
 
+.accepted-extensions {
+    color: #000;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 4px;
+    max-width: 600px;
+    margin: 8px auto;
+    line-height: 1.4;
+}
+
+.accepted-extensions span {
+    background-color: #e1f5ec;
+    border: 1px solid var(--primary-color);
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 0.9rem;
+}
+
 .logo-header {
     max-width: 200px;
     width: 100%;

--- a/app/templates/converter.html
+++ b/app/templates/converter.html
@@ -36,10 +36,26 @@
                 Arraste os arquivos aqui ou clique para selecionar
             </div>
             <ul id="lista-arquivos"></ul>
-            <p class="subtitulo">
-              Extensões aceitas: DOC, DOCX, ODT, RTF, TXT, HTML, XLS,
-              XLSX, ODS, PPT, PPTX, ODP, JPG, JPEG, PNG, BMP, TIFF
-            </p>
+            <div class="subtitulo accepted-extensions">
+              <strong>Extensões aceitas:</strong>
+              <span>DOC</span>
+              <span>DOCX</span>
+              <span>ODT</span>
+              <span>RTF</span>
+              <span>TXT</span>
+              <span>HTML</span>
+              <span>XLS</span>
+              <span>XLSX</span>
+              <span>ODS</span>
+              <span>PPT</span>
+              <span>PPTX</span>
+              <span>ODP</span>
+              <span>JPG</span>
+              <span>JPEG</span>
+              <span>PNG</span>
+              <span>BMP</span>
+              <span>TIFF</span>
+            </div>
             {{ macros.preview_area('spinner-' ~ prefix, 'preview-' ~ prefix) }}
             <button id="converter-btn" disabled>Converter Todos</button>
         </section>


### PR DESCRIPTION
## Summary
- make accepted extensions list easier to read
- add styling for accepted extensions in converter page

## Testing
- `pre-commit run --files app/templates/converter.html app/static/style.css`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fba48c4fc832198974233bf55023c