### PR TITLE
Fix dropzone initialization for converter

### DIFF
--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -8,6 +8,7 @@ import {
   API_BASE,
 } from './api.js';
 import { PdfWidget } from './pdf-widget.js';
+import { createFileDropzone } from '../fileDropzone.js';
 
 // grupos de extensões
 const PDF_EXTS   = ['pdf'];
@@ -15,6 +16,12 @@ const IMG_EXTS   = ['jpg','jpeg','png','bmp','tiff'];
 const DOC_EXTS   = ['doc','docx','odt','rtf','txt','html'];
 const SHEET_EXTS = ['xls','xlsx','ods'];
 const PPT_EXTS   = ['ppt','pptx','odp'];
+
+const fileInput    = document.getElementById('file-input');
+const dropzoneEl   = document.getElementById('dropzone');
+const fileList     = document.getElementById('lista-arquivos');
+const converterBtn = document.getElementById('converter-btn');
+let dz = null;
 
 function makePagesSortable(containerEl) {
   if (window.Sortable) {
@@ -67,6 +74,18 @@ function handleAction(btn, files, container, widget) {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
+  if (fileInput && dropzoneEl) {
+    dz = createFileDropzone({
+      dropzone: dropzoneEl,
+      input: fileInput,
+      list: fileList,
+      multiple: true,
+      onChange: files => {
+        if (converterBtn) converterBtn.disabled = files.length === 0;
+      }
+    });
+  }
+
   document.querySelectorAll('.dropzone').forEach(dzEl => {
     const widget = new PdfWidget({
       dropzoneEl: dzEl,

--- a/app/templates/converter.html
+++ b/app/templates/converter.html
@@ -25,14 +25,14 @@
         {% import 'macros.html' as macros %}
         {% set prefix = 'convert' %}
         <section class="card">
-            <div id="dropzone-{{ prefix }}" class="dropzone"
+            <div id="dropzone" class="dropzone"
                  data-preview="#preview-{{ prefix }}"
                  data-spinner="#spinner-{{ prefix }}"
                  data-action="#converter-btn"
                  data-list="#lista-arquivos"
                  data-extensions=".doc,.docx,.odt,.rtf,.txt,.html,.xls,.xlsx,.ods,.ppt,.pptx,.odp,.jpg,.jpeg,.png,.bmp,.tiff"
                  data-multiple="true">
-                <input type="file" id="input-{{ prefix }}" accept=".doc,.docx,.odt,.rtf,.txt,.html,.xls,.xlsx,.ods,.ppt,.pptx,.odp,.jpg,.jpeg,.png,.bmp,.tiff" multiple>
+                <input type="file" id="file-input" accept=".doc,.docx,.odt,.rtf,.txt,.html,.xls,.xlsx,.ods,.ppt,.pptx,.odp,.jpg,.jpeg,.png,.bmp,.tiff" multiple>
                 Arraste os arquivos aqui ou clique para selecionar
             </div>
             <ul id="lista-arquivos"></ul>


### PR DESCRIPTION
## Summary
- capture converter page input before initializing the dropzone
- add ids `dropzone` and `file-input` to match new JS logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fbb8a6ea883219d232a46f04842bb