### PR TITLE
Add dynamic extension badges to converter page

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -109,7 +109,13 @@ def create_app():
 
     @app.route("/converter")
     def converter_page():
-        return render_template("converter.html")
+        extensions = [
+            'doc','docx','odt','rtf','txt','html',
+            'xls','xlsx','ods',
+            'ppt','pptx','odp',
+            'jpg','jpeg','png','bmp','tiff'
+        ]
+        return render_template("converter.html", extensions=extensions)
 
     @app.route("/merge")
     def merge_page():

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1029,3 +1029,22 @@ button:focus {
   background: rgba(52, 152, 219, 1);
   transform: scale(1.1);
 }
+
+/* Lista de extensões no Converter */
+.extensions-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: center;
+  margin: 1rem 0;
+}
+
+.ext-badge {
+  background-color: var(--primary-color);
+  color: #fff;
+  font-size: 0.875rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+}

--- a/app/templates/converter.html
+++ b/app/templates/converter.html
@@ -36,25 +36,11 @@
                 Arraste os arquivos aqui ou clique para selecionar
             </div>
             <ul id="lista-arquivos"></ul>
-            <div class="subtitulo accepted-extensions">
-              <strong>Extensões aceitas:</strong>
-              <span>DOC</span>
-              <span>DOCX</span>
-              <span>ODT</span>
-              <span>RTF</span>
-              <span>TXT</span>
-              <span>HTML</span>
-              <span>XLS</span>
-              <span>XLSX</span>
-              <span>ODS</span>
-              <span>PPT</span>
-              <span>PPTX</span>
-              <span>ODP</span>
-              <span>JPG</span>
-              <span>JPEG</span>
-              <span>PNG</span>
-              <span>BMP</span>
-              <span>TIFF</span>
+            <p class="subtitulo" style="color:#000;font-weight:600">Extensões aceitas:</p>
+            <div class="extensions-list">
+              {% for ext in extensions %}
+                <span class="ext-badge">{{ ext|upper }}</span>
+              {% endfor %}
             </div>
             {{ macros.preview_area('spinner-' ~ prefix, 'preview-' ~ prefix) }}
             <button id="converter-btn" disabled>Converter Todos</button>


### PR DESCRIPTION
## Summary
- pass list of supported extensions to the converter template
- show the extensions as styled badges
- style badges via new CSS rules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fbee3e358832195ed12cc7ebf923b