### PR TITLE
Improve extension badges UI

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1031,12 +1031,19 @@ button:focus {
 }
 
 /* Lista de extensões no Converter */
+.extensions-header p {
+  color: #333;
+  font-weight: 600;
+  text-align: center;
+  margin-bottom: 0.5rem;
+}
+
 .extensions-list {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
   justify-content: center;
-  margin: 1rem 0;
+  margin-bottom: 1rem;
 }
 
 .ext-badge {
@@ -1045,6 +1052,12 @@ button:focus {
   font-size: 0.875rem;
   font-weight: 500;
   text-transform: uppercase;
-  padding: 0.25rem 0.5rem;
-  border-radius: 0.25rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  transition: transform 0.2s;
+}
+
+.ext-badge:hover {
+  transform: translateY(-2px);
 }

--- a/app/templates/converter.html
+++ b/app/templates/converter.html
@@ -36,7 +36,9 @@
                 Arraste os arquivos aqui ou clique para selecionar
             </div>
             <ul id="lista-arquivos"></ul>
-            <p class="subtitulo" style="color:#000;font-weight:600">Extensões aceitas:</p>
+            <div class="extensions-header">
+              <p>Suporta conversão de:</p>
+            </div>
             <div class="extensions-list">
               {% for ext in extensions %}
                 <span class="ext-badge">{{ ext|upper }}</span>


### PR DESCRIPTION
## Summary
- update converter page text for supported file types
- overhaul extension badge styling

## Testing
- `pre-commit run --files app/templates/converter.html app/static/style.css`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fcd5b9180832194a39bb0215f7b64