### PR TITLE
Implement page preview API and compress mods

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,13 @@ que deseja manter. Utilize o botão "×" em cima da miniatura para removê-la da
 visualização. A lista de páginas selecionadas é enviada para o servidor no campo
 `pagesMap`.
 
+### Prévia de páginas no compress
+
+A rota `/api/pdf/preview` recebe um PDF e retorna um JSON com as URLs das miniaturas
+de cada página. Use este endpoint para exibir as páginas antes de enviar a
+compressão. O campo `mods` em `/api/pdf/compress` permite informar páginas removidas
+e rotações.
+
 ---
 
 ## 🧪 Testes

--- a/app/routes/compress.py
+++ b/app/routes/compress.py
@@ -1,12 +1,31 @@
 # app/routes/compress.py
 
-from flask import Blueprint, request, jsonify, send_file, render_template, after_this_request, abort, current_app
+from flask import Blueprint, request, jsonify, send_file, render_template, after_this_request, abort, current_app, url_for
 import os
-from ..services.compress_service import comprimir_pdf
+from ..services.compress_service import comprimir_pdf, gerar_previews
 import json
 from .. import limiter
 
 compress_bp = Blueprint('compress', __name__)
+
+
+@compress_bp.route('/preview', methods=['POST'])
+def preview():
+    if 'file' not in request.files:
+        return jsonify({'error': 'Nenhum arquivo enviado.'}), 400
+    file = request.files['file']
+    if file.filename == '':
+        return jsonify({'error': 'Nenhum arquivo selecionado.'}), 400
+    try:
+        names = gerar_previews(file)
+        urls = [
+            url_for('viewer.get_pdf', filename=n)
+            for n in names
+        ]
+        return jsonify({'pages': urls})
+    except Exception:
+        current_app.logger.exception('Erro gerando preview')
+        abort(500)
 
 # Limita este endpoint a no máximo 5 requisições por minuto por IP
 @compress_bp.route('/compress', methods=['POST'])
@@ -19,11 +38,19 @@ def compress():
     if file.filename == '':
         return jsonify({'error': 'Nenhum arquivo selecionado.'}), 400
 
-    mods = request.form.get('modificacoes')
-    modificacoes = None
-    if mods:
+    mods_field = request.form.get('mods')
+    mods = None
+    if mods_field:
         try:
-            modificacoes = json.loads(mods)
+            mods = json.loads(mods_field)
+        except json.JSONDecodeError:
+            return jsonify({'error': 'mods deve ser JSON valido'}), 400
+
+    mods_old = request.form.get('modificacoes')
+    modificacoes = None
+    if mods_old:
+        try:
+            modificacoes = json.loads(mods_old)
         except json.JSONDecodeError:
             return jsonify({'error': 'modificacoes deve ser JSON valido'}), 400
 
@@ -36,7 +63,12 @@ def compress():
             return jsonify({'error': 'rotations deve ser JSON valido'}), 400
 
     try:
-        output_path = comprimir_pdf(file, rotations=rotations, modificacoes=modificacoes)
+        output_path = comprimir_pdf(
+            file,
+            rotations=rotations,
+            modificacoes=modificacoes,
+            mods=mods
+        )
 
         @after_this_request
         def cleanup(response):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ Flask-WTF==1.2.1
 PyPDF2==3.0.1
 pillow==11.1.0
 python-dotenv>=1.1
+PyMuPDF==1.26.3

--- a/tests/test_compress.py
+++ b/tests/test_compress.py
@@ -1,0 +1,64 @@
+import json
+from io import BytesIO
+from PyPDF2 import PdfWriter, PdfReader
+from app import create_app
+
+
+def _three_page_pdf():
+    w = PdfWriter()
+    for _ in range(3):
+        w.add_blank_page(width=10, height=10)
+    buf = BytesIO()
+    w.write(buf)
+    buf.seek(0)
+    return buf
+
+
+def test_preview_generates_images(tmp_path):
+    app = create_app()
+    app.config['UPLOAD_FOLDER'] = tmp_path
+    app.config['WTF_CSRF_ENABLED'] = False
+    client = app.test_client()
+
+    data = {'file': (_three_page_pdf(), 'a.pdf')}
+    resp = client.post('/api/pdf/preview', data=data, content_type='multipart/form-data')
+    assert resp.status_code == 200
+    info = resp.get_json()
+    assert 'pages' in info
+    assert len(info['pages']) == 3
+    for url in info['pages']:
+        img_resp = client.get(url)
+        assert img_resp.status_code == 200
+        assert img_resp.mimetype == 'image/png'
+
+
+def test_compress_applies_mods(monkeypatch, tmp_path):
+    app = create_app()
+    app.config['UPLOAD_FOLDER'] = tmp_path
+    app.config['WTF_CSRF_ENABLED'] = False
+    client = app.test_client()
+
+    def fake_run(cmd, check=True, timeout=60):
+        out = None
+        for part in cmd:
+            if str(part).startswith('-sOutputFile='):
+                out = part.split('=', 1)[1]
+        src = cmd[-1]
+        if out:
+            import shutil
+            shutil.copyfile(src, out)
+
+    monkeypatch.setattr('subprocess.run', fake_run)
+
+    mods = {"removed": [1], "rotations": {"2": 90}}
+    data = {
+        'file': (_three_page_pdf(), 'b.pdf'),
+        'mods': json.dumps(mods)
+    }
+    resp = client.post('/api/pdf/compress', data=data, content_type='multipart/form-data')
+    assert resp.status_code == 200
+    reader = PdfReader(BytesIO(resp.data))
+    assert len(reader.pages) == 2
+    rotation = reader.pages[1].get('/Rotate')
+    assert rotation in (90, 270)
+


### PR DESCRIPTION
## Summary
- generate PNG previews using PyMuPDF
- allow removing and rotating pages before compressing
- expose new `/api/pdf/preview` endpoint
- document the preview route
- test preview and compress page modifications

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fcf7ce8088321956d2638ff517852