### PR TITLE
Implement data URI preview for compress

### DIFF
--- a/app/templates/compress.html
+++ b/app/templates/compress.html
@@ -26,7 +26,7 @@
         {% import 'macros.html' as macros %}
         <section class="card">
             {% set prefix = 'compress' %}
-            <form action="{{ url_for('compress.compress') }}" method="post" enctype="multipart/form-data">
+            <form id="compress-form" action="{{ url_for('compress.compress') }}" method="post" enctype="multipart/form-data">
                 <label>Escolha um arquivo PDF:</label>
                 <div id="dropzone-{{ prefix }}" class="dropzone"
                      data-preview="#preview-{{ prefix }}"
@@ -38,6 +38,8 @@
                     Arraste o arquivo aqui ou clique para selecionar
                 </div>
                 {{ macros.preview_area('spinner-' ~ prefix, 'preview-' ~ prefix) }}
+                <!-- preview de páginas (injetado pelo JS) -->
+                <ul id="preview-list" class="buffer-preview"></ul>
                 <button id="btn-{{ prefix }}" type="submit" disabled>Comprimir PDF</button>
             </form>
         </section>

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ PyPDF2==3.0.1
 pillow==11.1.0
 python-dotenv>=1.1
 PyMuPDF==1.26.3
+pdf2image==1.17.0


### PR DESCRIPTION
## Summary
- support previewing PDF pages as data URIs
- allow passing level and page modifications on compress
- expose new `/compress/preview` endpoint
- update compress form with preview list
- add pdf2image dependency

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fd60b35e08321a7df0c807047332c