### PR TITLE
Fix compress preview DOM duplication

### DIFF
--- a/app/templates/compress.html
+++ b/app/templates/compress.html
@@ -59,5 +59,5 @@
         <a href="{{ url_for('split_page') }}"><button>Dividir PDF</button></a>
     </div>
 
-    {% include '_preview_modal.html' %}
+    {# Não usamos o modal de preview nesta página #}
 </body></html>


### PR DESCRIPTION
## Summary
- remove modal include from compress page since it's unused

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fdfe9e6508321bd8b9c87e8476e1e